### PR TITLE
Allow global operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "eip-operator"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eip-operator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ This operator manages the following:
     ```
 5. Create a K8S Deployment.
 You must specify the `CLUSTER_NAME` environment variable. `NAMESPACE` and `DEFAULT_TAGS` are optional.
+If you do not set the `NAMESPACE` environment variable, the eip-operator will operate on all namespaces.
+Even in this global mode, the eip and pod must be in the same namespace.
     ```yaml
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
If you do not set the `NAMESPACE` environment variable, the eip-operator will operate on all namespaces.
Even in this global mode, the eip and pod must be in the same namespace.