### PR TITLE
Allow passing in arbitrary otel fields at setup time

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ This operator manages the following:
                     "ec2:DeleteTags",
                     "ec2:DescribeInstances",
                     "ec2:ModifyNetworkInterfaceAttribute",
+                    "servicequotas:GetServiceQuota"
                 ],
                 "Effect": "Allow",
-                "Resource": "*",
+                "Resource": "*"
             }
-        ],
+        ]
     }
     ```
 2. Create a K8S ServiceAccount.
@@ -153,6 +154,8 @@ We now have support for sending traces using the OpenTelemetry OTLP format. This
 `OPENTELEMETRY_ENDPOINT` is the endpoint to send the logs to.
 
 `OPENTELEMETRY_HEADERS` is a json formatted map of key/value pairs to be included in the GRPC request headers.
+
+`OPENTELEMETRY_TOPLEVEL_FIELDS` is a json formatted map of key/value pairs to be included in all traces.
 
 `OPENTELEMETRY_SAMPLE_RATE` is a float value controlling the trace sample rate. Default is 0.05.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ We now have support for sending traces using the OpenTelemetry OTLP format. This
 
 `OPENTELEMETRY_HEADERS` is a json formatted map of key/value pairs to be included in the GRPC request headers.
 
-`OPENTELEMETRY_TOPLEVEL_FIELDS` is a json formatted map of key/value pairs to be included in all traces.
+`OPENTELEMETRY_TOPLEVEL_FIELDS` is a json formatted map of key/value pairs to be included in all trace spans emitted from the service.
 
 `OPENTELEMETRY_SAMPLE_RATE` is a float value controlling the trace sample rate. Default is 0.05.
 


### PR DESCRIPTION
Pass in a key value map of fields or features to add to the open telemetry config.