### PR TITLE
bump k8s-openapi to 0.16.0 and kube to 0.75.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,10 +4,11 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
 dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -1119,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
+checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
  "base64",
  "bytes",
@@ -1133,8 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.74.0"
-source = "git+https://github.com/MaterializeInc/kube-rs.git?branch=fix_duplicate_finalizers#28b84d9d618c28902c8dc80757b387a44976ca94"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1144,8 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.74.0"
-source = "git+https://github.com/MaterializeInc/kube-rs.git?branch=fix_duplicate_finalizers#28b84d9d618c28902c8dc80757b387a44976ca94"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
 dependencies = [
  "base64",
  "bytes",
@@ -1178,8 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.74.0"
-source = "git+https://github.com/MaterializeInc/kube-rs.git?branch=fix_duplicate_finalizers#28b84d9d618c28902c8dc80757b387a44976ca94"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1195,8 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.74.0"
-source = "git+https://github.com/MaterializeInc/kube-rs.git?branch=fix_duplicate_finalizers#28b84d9d618c28902c8dc80757b387a44976ca94"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98459d53b2841237392cd6959956185b2df15c19d32c3b275ed6ca7b7ee1adae"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1207,8 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.74.0"
-source = "git+https://github.com/MaterializeInc/kube-rs.git?branch=fix_duplicate_finalizers#28b84d9d618c28902c8dc80757b387a44976ca94"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7769af142ee2e46bfa44bd393cf7f40b9d8b80d2e11f6317399551ed17760beb"
 dependencies = [
  "ahash",
  "backoff",

--- a/cilium_eip_no_masquerade_agent/Cargo.toml
+++ b/cilium_eip_no_masquerade_agent/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 [dependencies]
 futures = "0.3"
 ipnetwork = "0.20"
-k8s-openapi = { version = "0.15", default-features = false, features = ["v1_21"] }
-kube = { git = "https://github.com/MaterializeInc/kube-rs.git", branch = "fix_duplicate_finalizers", features = ["derive"] }
-kube-runtime = { git = "https://github.com/MaterializeInc/kube-rs.git", branch = "fix_duplicate_finalizers" }
+k8s-openapi = { version = "0.16", default-features = false, features = ["v1_22"] }
+kube = { version = "0.75", features = ["derive"] }
+kube-runtime = { version = "0.75" }
 rand = "0.8"
 rtnetlink = { git = "https://github.com/MaterializeInc/netlink.git", branch = "priority_support" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/cilium_eip_no_masquerade_agent/src/main.rs
+++ b/cilium_eip_no_masquerade_agent/src/main.rs
@@ -153,7 +153,11 @@ async fn reconcile_pod(
 }
 
 /// Requeues the operation if there is an error.
-fn on_error(_error: &kube_runtime::finalizer::Error<Error>, _context: Arc<ContextData>) -> Action {
+fn on_error(
+    _pod: Arc<Pod>,
+    _error: &kube_runtime::finalizer::Error<Error>,
+    _context: Arc<ContextData>,
+) -> Action {
     Action::requeue(Duration::from_millis(thread_rng().gen_range(4000..8000)))
 }
 

--- a/eip_operator/Cargo.toml
+++ b/eip_operator/Cargo.toml
@@ -12,9 +12,9 @@ aws-sdk-servicequotas = "0.19"
 aws-smithy-http = "0.49"
 futures = "0.3"
 json-patch = "0.2"
-k8s-openapi = { version = "0.15", default-features = false, features = ["v1_21"] }
-kube = { git = "https://github.com/MaterializeInc/kube-rs.git", branch = "fix_duplicate_finalizers", features = ["derive"] }
-kube-runtime = { git = "https://github.com/MaterializeInc/kube-rs.git", branch = "fix_duplicate_finalizers" }
+k8s-openapi = { version = "0.16", default-features = false, features = ["v1_22"] }
+kube = { version = "0.75", features = ["derive"] }
+kube-runtime = { version = "0.75" }
 rand = "0.8"
 schemars = "0.8"
 serde = "1"

--- a/eip_operator/src/main.rs
+++ b/eip_operator/src/main.rs
@@ -702,7 +702,11 @@ async fn reconcile_eip(
 }
 
 /// Requeues the operation if there is an error.
-fn on_error(_error: &kube_runtime::finalizer::Error<Error>, _context: Arc<ContextData>) -> Action {
+fn on_error<T>(
+    _obj: Arc<T>,
+    _error: &kube_runtime::finalizer::Error<Error>,
+    _context: Arc<ContextData>,
+) -> Action {
     Action::requeue(Duration::from_millis(thread_rng().gen_range(4000..8000)))
 }
 

--- a/eip_operator_shared/Cargo.toml
+++ b/eip_operator_shared/Cargo.toml
@@ -12,7 +12,7 @@ aws-smithy-http = "0.49"
 futures = "0.3"
 hyper = { version = "0.14.20", features = ["http2"] }
 hyper-tls = { version = "0.5.0" }
-kube = { git = "https://github.com/MaterializeInc/kube-rs.git", branch = "fix_duplicate_finalizers", features = ["derive"] }
+kube = { version = "0.75", features = ["derive"] }
 native-tls = { version = "0.2.10", features = ["alpn"] }
 opentelemetry = { version = "0.17", features = ["rt-tokio", "trace"] }
 opentelemetry-otlp = { version = "0.10" }


### PR DESCRIPTION
Bumps k8s-openapi to 0.16.0 and kube to 0.75.0.
Also gets us off our fork of kube, since the duplicate finalizer fix is included in the latest version.

The API changed slightly for the `on_error` callback, since we now need to accept the K8S resource that failed to reconcile as an argument.