### PR TITLE
also catch errors when waiting on crd initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "kube",
+ "kube-runtime",
  "native-tls",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/eip_operator/src/main.rs
+++ b/eip_operator/src/main.rs
@@ -136,7 +136,7 @@ async fn register_eip_custom_resource(k8s_client: Client) -> Result<(), Error> {
         "eips.materialize.cloud",
         conditions::is_crd_established(),
     );
-    let _ = tokio::time::timeout(std::time::Duration::from_secs(10), establish).await?;
+    tokio::time::timeout(std::time::Duration::from_secs(10), establish).await??;
     Ok(())
 }
 

--- a/eip_operator_shared/Cargo.toml
+++ b/eip_operator_shared/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.3"
 hyper = { version = "0.14.20", features = ["http2"] }
 hyper-tls = { version = "0.5.0" }
 kube = { version = "0.75", features = ["derive"] }
+kube-runtime = { version = "0.75" }
 native-tls = { version = "0.2.10", features = ["alpn"] }
 opentelemetry = { version = "0.17", features = ["rt-tokio", "trace"] }
 opentelemetry-otlp = { version = "0.10" }

--- a/eip_operator_shared/src/lib.rs
+++ b/eip_operator_shared/src/lib.rs
@@ -40,6 +40,11 @@ pub enum Error {
         #[from]
         source: kube::Error,
     },
+    #[error("Kubernetes error: {source}")]
+    KubeRuntimeWaitError {
+        #[from]
+        source: kube_runtime::wait::Error,
+    },
     #[error("No EIP found with that podName.")]
     NoEipResourceWithThatPodName(String),
     #[error("EIP does not have a status.")]


### PR DESCRIPTION
just swallowing these errors is bad, because it causes us to miss things like incorrect permissions