### PR TITLE
Emit structured JSONL log messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,12 +2467,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/eip_operator_shared/Cargo.toml
+++ b/eip_operator_shared/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tonic = { version = "0.7.2", features = ["transport"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.17"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "json"] }
 
 rtnetlink = { git = "https://github.com/MaterializeInc/netlink.git", branch = "priority_support" }
 async-trait = "0.1.59"

--- a/eip_operator_shared/src/lib.rs
+++ b/eip_operator_shared/src/lib.rs
@@ -259,15 +259,19 @@ where
             let otel_layer = tracing_opentelemetry::layer()
                 .with_tracer(tracer)
                 .with_filter(otel_targets);
-            let stdout_layer =
-                fmt::Layer::default().with_filter(MyEnvFilter(EnvFilter::from_default_env()));
+            let stdout_layer = fmt::layer()
+                .json()
+                .with_filter(MyEnvFilter(EnvFilter::from_default_env()));
             tracing_subscriber::Registry::default()
                 .with(otel_layer)
                 .with(stdout_layer)
                 .init();
         }
         Err(_) => {
-            tracing_subscriber::fmt::init();
+            tracing_subscriber::fmt()
+                .with_env_filter(EnvFilter::from_default_env())
+                .json()
+                .init();
         }
     };
     f().await


### PR DESCRIPTION
Previously, we logged colorized messages, which isn't great for log aggregators and queryability in general. Let's use JSONL.