### PR TITLE
Refactor EIP Operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "async-trait"
@@ -74,7 +74,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -85,18 +85,19 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.55.3"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
+checksum = "84f9625b71b3ee4adbfbca369c6680d156e316ed86d2c7199a2a134563917414"
 dependencies = [
  "aws-credential-types",
  "aws-http",
+ "aws-runtime",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
- "aws-smithy-http-tower",
  "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -105,157 +106,138 @@ dependencies = [
  "hyper",
  "time",
  "tokio",
- "tower",
  "tracing",
 ]
 
 [[package]]
 name = "aws-credential-types"
-version = "0.55.3"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
+checksum = "5924466398ac76ffd411d297b9d516dcebb0577f7344c0c15fd8e8e04d9c7895"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
- "fastrand",
- "tokio",
- "tracing",
  "zeroize",
 ]
 
 [[package]]
-name = "aws-endpoint"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
- "http",
- "regex",
- "tracing",
-]
-
-[[package]]
 name = "aws-http"
-version = "0.55.3"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
+checksum = "bb9a3aa335a105a00975c971f1dad403c3175f2a210d98f39345c6af53923912"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "http",
  "http-body",
- "lazy_static",
- "percent-encoding",
  "pin-project-lite",
  "tracing",
 ]
 
 [[package]]
-name = "aws-sdk-ec2"
-version = "0.28.0"
+name = "aws-runtime"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab2493c5857725eeafe12ec66ba4ce6feb3355e3af6828d9ef28d6152972a27"
+checksum = "b75844ecbdf3dc5e0f5ac5fd1088fb1623849990ea9445d2826258ce63be4de5"
 dependencies = [
  "aws-credential-types",
- "aws-endpoint",
  "aws-http",
- "aws-sig-auth",
+ "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "fastrand",
+ "http",
+ "percent-encoding",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-ec2"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eadf3b2bbaed2435729f6aadc5355d06a8e00cf819309a67d736594b04880ba"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "bytes",
  "fastrand",
  "http",
  "regex",
- "tokio-stream",
- "tower",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-servicequotas"
-version = "0.28.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bc114a6e96f15b8ca1a68621ef44ba4ded021e9587633efac3cfedf716929a"
+checksum = "e9177a64ca9f65cf293e2f3223b3e87594a3271688c741a61ff03574c6a0fdf4"
 dependencies = [
  "aws-credential-types",
- "aws-endpoint",
  "aws-http",
- "aws-sig-auth",
+ "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
- "aws-smithy-http-tower",
  "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "http",
  "regex",
- "tokio-stream",
- "tower",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.28.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
+checksum = "a4e3958c43a78f6c3822e62009a35802af5cc7c120fbe8e60b98565604569aae"
 dependencies = [
  "aws-credential-types",
- "aws-endpoint",
  "aws-http",
- "aws-sig-auth",
+ "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
- "aws-smithy-http-tower",
  "aws-smithy-json",
  "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "bytes",
  "http",
  "regex",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-sig-auth"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-http",
- "aws-types",
- "http",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "0.55.3"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
+checksum = "06130e3686db3c5ae2fc44b3516fffe6b4d4eccebe09bd8ccc4067f3c9c183fb"
 dependencies = [
+ "aws-credential-types",
  "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
  "form_urlencoded",
  "hex",
  "hmac",
@@ -270,127 +252,132 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.55.3"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bda3996044c202d75b91afeb11a9afae9db9a721c6a7a427410018e286b880"
+checksum = "d787b7e07925b450bed90d9d29ac8e57006c9c2ac907151d175ac0e376bfee0e"
 dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "aws-smithy-client"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "pin-project-lite",
- "tokio",
- "tower",
- "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.55.3"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
+checksum = "96daaad925331c72449423574fdc72b54af780d5a23ace3c0a6ad0ccbf378715"
 dependencies = [
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http",
  "http-body",
- "hyper",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-tower"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "bytes",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.55.3"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
+checksum = "0ff985bee3fe21046dc501fadc1d04a1161977c55a0cbbccd9b111c18206aa64"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.55.3"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
+checksum = "cb4006503693766d34717efc5f58325062845fce26a683a71b70f23156d72e67"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "0.55.3"
+name = "aws-smithy-runtime"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
+checksum = "d28af854558601b4202a4273b9720aebe43d73e472143e6056f16e3bd90bc837"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "0.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c68e17e754b86da350b43add38294189121a880e9c3fb454f83ff7044f5257"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97b978d8a351ea5744206ecc643a1d3806628680e9f151b4d6b7a76fec1596f"
 dependencies = [
  "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
  "itoa",
  "num-integer",
+ "pin-project-lite",
+ "pin-utils",
  "ryu",
+ "serde",
  "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.55.3"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
+checksum = "97500a0d0884b9576e65076075f81d899cfbb84f7db5ca1dd317f0582204e528"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.55.3"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
+checksum = "61065f0c6070cb0f9aaddfa614605fb1049908481da71ba5b39b2ffca12f57e4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "http",
  "rustc_version",
@@ -399,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -455,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -470,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64-simd"
@@ -492,9 +479,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "block-buffer"
@@ -507,27 +494,27 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bytes-utils"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
@@ -535,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -547,15 +534,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "winapi",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -578,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -588,37 +575,33 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -632,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -642,27 +625,36 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -689,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.11"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "eip-operator"
@@ -722,9 +714,12 @@ name = "eip-operator-shared"
 version = "0.3.0"
 dependencies = [
  "async-trait",
+ "aws-config",
  "aws-sdk-ec2",
  "aws-sdk-servicequotas",
  "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "futures",
  "hyper",
  "hyper-tls",
@@ -733,6 +728,7 @@ dependencies = [
  "native-tls",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rand",
  "rtnetlink",
  "serde",
@@ -748,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "equivalent"
@@ -760,33 +756,19 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fnv"
@@ -811,9 +793,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -874,7 +856,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -919,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -930,9 +912,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -946,7 +934,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.1",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -961,9 +949,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -971,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -992,18 +980,18 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1012,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -1023,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -1035,15 +1023,15 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1108,16 +1096,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -1147,12 +1135,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.1"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1162,17 +1150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -1197,15 +1174,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1223,14 +1200,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
+name = "jsonpath-rust"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+checksum = "06cc127b7c3d270be504572364f9569761a180b981919dd0d87693a7f5fb7829"
 dependencies = [
- "log",
- "serde",
+ "pest",
+ "pest_derive",
+ "regex",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1265,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.87.1"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34392aea935145070dcd5b39a6dea689ac6534d7d117461316c3d157b1d0fc3"
+checksum = "3499c8d60c763246c7a213f51caac1e9033f46026904cb89bc8951ae8601f26e"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1277,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.87.1"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7266548b9269d9fa19022620d706697e64f312fb2ba31b93e6986453fcc82c92"
+checksum = "033450dfa0762130565890dadf2f8835faedf749376ca13345bcd8ecd6b5f29f"
 dependencies = [
  "base64",
  "bytes",
@@ -1292,7 +1271,7 @@ dependencies = [
  "hyper",
  "hyper-openssl",
  "hyper-timeout",
- "jsonpath_lib",
+ "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "openssl",
@@ -1312,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.87.1"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8321c315b96b59f59ef6b33f604b84b905ab8f9ff114a4f909d934c520227b1"
+checksum = "b5bba93d054786eba7994d03ce522f368ef7d48c88a1826faa28478d85fb63ae"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1330,29 +1309,29 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.87.1"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54591e1f37fc329d412c0fdaced010cc1305b546a39f283fc51700f8fb49421"
+checksum = "91e98dd5e5767c7b894c1f0e41fd628b145f808e981feb8b08ed66455d47f1a4"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.87.1"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e511e2c1a368d9d4bf6e70db58197e535d818df355b5a2007a8aeb17a370a8ba"
+checksum = "2d8893eb18fbf6bb6c80ef6ee7dd11ec32b1dc3c034c988ac1b3a84d46a230ae"
 dependencies = [
  "ahash",
  "async-trait",
  "backoff",
  "derivative",
  "futures",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -1375,9 +1354,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linked-hash-map"
@@ -1396,15 +1375,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1412,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "matchers"
@@ -1422,20 +1401,20 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
 name = "matchit"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mime"
@@ -1445,22 +1424,22 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1520,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842c6770fc4bb33dd902f41829c61ef872b8e38de1405aa0b938b27b8fba12c3"
+checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
 dependencies = [
  "bytes",
  "futures",
@@ -1563,7 +1542,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "cfg-if",
  "libc",
 ]
@@ -1579,20 +1558,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -1609,26 +1593,26 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.61"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1645,7 +1629,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1656,9 +1640,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.97"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -1668,26 +1652,32 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.2.5",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
+checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
 dependencies = [
  "async-trait",
  "futures-core",
  "http",
+ "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_api",
  "opentelemetry_sdk",
  "prost",
  "thiserror",
@@ -1697,11 +1687,11 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
+checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
- "opentelemetry_api",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -1709,47 +1699,30 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
  "opentelemetry",
 ]
 
 [[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
-version = "0.20.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
- "ordered-float 3.9.2",
+ "opentelemetry",
+ "ordered-float 4.2.0",
  "percent-encoding",
  "rand",
- "regex",
- "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1757,18 +1730,18 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "3.9.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -1797,22 +1770,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pem"
@@ -1826,35 +1799,80 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1864,9 +1882,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1876,9 +1900,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -1947,22 +1971,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1971,7 +1996,18 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1979,6 +2015,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rtnetlink"
@@ -2015,37 +2057,36 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2074,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrecy"
@@ -2090,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -2103,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2113,15 +2154,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -2132,19 +2173,19 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.0",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2160,11 +2201,10 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "indexmap 2.2.1",
  "itoa",
  "ryu",
  "serde",
@@ -2172,11 +2212,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
 dependencies = [
- "indexmap 2.2.1",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -2185,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2196,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -2214,27 +2254,27 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2262,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2279,43 +2319,41 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2323,10 +2361,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2334,26 +2375,26 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -2363,7 +2404,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2378,13 +2419,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2422,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2490,7 +2531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "base64",
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2536,7 +2577,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2551,27 +2592,31 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc09e402904a5261e42cf27aea09ccb7d5318c6717a9eec3d8e2e65c56b18f19"
+checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -2586,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2607,30 +2652,36 @@ dependencies = [
 
 [[package]]
 name = "treediff"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
+checksum = "4d127780145176e2b5d16611cc25a900150e86e9fd79d3bde6ff3a37359c9cb5"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2640,9 +2691,15 @@ checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "urlencoding"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "uuid"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 
 [[package]]
 name = "valuable"
@@ -2685,9 +2742,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2695,24 +2752,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2720,22 +2777,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -2760,12 +2827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2774,94 +2841,160 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "xmlparser"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 
 # Use this section only to change the source of dependencies that might

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,4 @@
+[graph]
 targets = [
     { triple = "aarch64-apple-darwin" },
     { triple = "aarch64-unknown-linux-gnu" },
@@ -6,7 +7,7 @@ targets = [
 ]
 
 [advisories]
-vulnerability = "deny"
+version = 2
 
 [bans]
 multiple-versions = "deny"
@@ -20,9 +21,10 @@ skip = [
     { name = "hashbrown", version = "0.12.3" },
     { name = "hashbrown", version = "0.14.0" },
     { name = "nix", version = "0.26.4" },
-    { name = "nix", version = "0.27.1" },
     { name = "ordered-float", version = "2.10.0" },
-    { name = "ordered-float", version = "3.4.0" },
+    { name = "fastrand", version = "2.0.1" },
+    { name = "regex-automata", version = "0.4.6" },
+    { name = "regex-syntax", version = "0.6.29" },
 ]
 
 # Use `tracing` instead.
@@ -35,6 +37,7 @@ name = "env_logger"
 name = "rustls"
 
 [licenses]
+version = 2
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
@@ -42,7 +45,6 @@ allow = [
     "MIT",
     "Unicode-DFS-2016",
 ]
-copyleft = "deny"
 
 [[licenses.clarify]]
 name = "ring"

--- a/eip_operator/Cargo.toml
+++ b/eip_operator/Cargo.toml
@@ -7,20 +7,10 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { version = "0.55.1", default-features = false, features = [
-  "native-tls",
-] }
-aws-sdk-ec2 = { version = "0.28", default-features = false, features = [
-  "native-tls",
-  "rt-tokio",
-] }
-aws-sdk-servicequotas = { version = "0.28", default-features = false, features = [
-  "native-tls",
-  "rt-tokio",
-] }
-aws-smithy-http = { version = "0.55", default-features = false, features = [
-  "rt-tokio",
-] }
+aws-config = { version = "0.101", default-features = false}
+aws-sdk-ec2 = { version = "0.38", default-features = false, features = [ "rt-tokio" ] }
+aws-sdk-servicequotas = { version = "0.38", default-features = false, features = [ "rt-tokio" ] }
+aws-smithy-http = { version = "0.59", default-features = false, features = [ "rt-tokio" ] }
 futures = { workspace = true }
 
 

--- a/eip_operator/src/controller/eip.rs
+++ b/eip_operator/src/controller/eip.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use k8s_openapi::api::core::v1::{Node, Pod};
 use k8s_openapi::Metadata;
 use kube::api::{Api, ListParams};
-use kube::Client;
+use kube::{Client, ResourceExt};
 use kube_runtime::controller::Action;
 use tracing::instrument;
 use tracing::{error, info, warn};
@@ -47,8 +47,7 @@ impl k8s_controller::Context for Context {
         client: Client,
         eip: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
-        let namespaced = Api::namespaced(client.clone(), eip.namespace().unwrap());
-        let eip_api = namespaced;
+        let eip_api = Api::namespaced(client.clone(), eip.namespace().unwrap());
         let pod_api = Api::<Pod>::namespaced(client.clone(), eip.namespace().unwrap());
         let node_api = Api::<Node>::all(client.clone());
 
@@ -68,7 +67,7 @@ impl k8s_controller::Context for Context {
         .ok_or(Error::MissingAddresses)?;
 
         // Ensure the EIP Exists
-        let _allocation_id = match addresses.len() {
+        let (allocation_id, public_ip) = match addresses.len() {
             0 => {
                 let response = crate::aws::allocate_address(
                     &self.ec2_client,
@@ -82,9 +81,7 @@ impl k8s_controller::Context for Context {
                 .await?;
                 let allocation_id = response.allocation_id.ok_or(Error::MissingAllocationId)?;
                 let public_ip = response.public_ip.ok_or(Error::MissingPublicIp)?;
-                status.allocation_id = Some(allocation_id.clone());
-                status.public_ip_address = Some(public_ip);
-                allocation_id
+                (allocation_id, public_ip)
             }
             1 => {
                 let allocation_id = addresses[0]
@@ -95,106 +92,117 @@ impl k8s_controller::Context for Context {
                     .public_ip
                     .as_ref()
                     .ok_or(Error::MissingPublicIp)?;
-                status.allocation_id = Some(allocation_id.clone());
-                status.public_ip_address = Some(public_ip.clone());
-                allocation_id.to_owned()
+                (allocation_id.to_owned(), public_ip.to_owned())
             }
             _ => {
                 return Err(Error::MultipleEipsTaggedForPod);
             }
         };
-
-        // Handle association / disassociatino
-        // disassociate if:
-        // - associated, but no longer has a claim (with caveot)
-        // - resource with claim is terminating or gone
-        // - resource with claim no longer matches
-        // associate if
-        //  - not associated and claim
-        let originally_unclaimed = status.claim.is_some();
+        crate::eip::set_status_created(&eip_api, name, &allocation_id, &public_ip).await?;
+        status.allocation_id = Some(allocation_id);
+        status.public_ip_address = Some(public_ip);
 
         // get potential attachments
-        let matched_pods: Vec<Pod> = if eip.selects_with_pod() {
-            pod_api
-                .list(&ListParams::default())
-                .await?
-                .into_iter()
-                .filter(|pod| eip.matches_pod(pod) && pod.metadata.deletion_timestamp.is_none())
-                .collect()
-        } else {
-            vec![]
-        };
-        let matched_nodes: Vec<Node> = if eip.selects_with_node() {
-            node_api
-                .list(&ListParams::default())
-                .await?
-                .into_iter()
-                .filter(|node| {
-                    eip.matches_node(node) && node.metadata().deletion_timestamp.is_none()
-                })
-                .collect()
-        } else {
-            vec![]
-        };
+        let mut matched_pods: Vec<Pod> = vec![];
+        let mut matched_nodes: Vec<Node> = vec![];
 
-        // Check to make sure our resource still matches
-        // incase our selectors have updated, or the nodes/pods we have
-        // claimed have changed
-        let selector_or_resource_changed_claim = match &eip.spec.selector {
-            EipSelector::Pod { pod_name: _ } => {
-                // pods match by name which is unique within a namespace and cannot be renamed
-                // if this list is empty we should drop the claim and disassociate
-                // otherwise we're good
-                matched_pods.is_empty()
+        match eip.spec.selector {
+            EipSelector::Pod { ref pod_name } => {
+                matched_pods = pod_api
+                    .list(&ListParams {
+                        field_selector: Some(format!("metadata.name={}", pod_name)),
+                        ..Default::default()
+                    })
+                    .await?
+                    .into_iter()
+                    .filter(|pod| pod.metadata.deletion_timestamp.is_none())
+                    .collect::<Vec<Pod>>();
+                matched_pods.sort_unstable_by_key(|s| s.name_unchecked());
             }
-            EipSelector::Node { selector: _ } => {
-                // check if our claim is still in the node match list
-                // if so we don't need to disassociate
-                !matched_nodes
+            EipSelector::Node { ref selector } => {
+                let label_selector = selector
                     .iter()
-                    .any(|n| n.metadata.name == status.claim)
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<String>>()
+                    .join(",");
+                matched_nodes = node_api
+                    .list(&ListParams {
+                        label_selector: Some(label_selector),
+                        ..Default::default()
+                    })
+                    .await?
+                    .into_iter()
+                    .filter(|node| node.metadata().deletion_timestamp.is_none())
+                    .collect::<Vec<Node>>();
+                matched_nodes.sort_unstable_by_key(|s| s.name_unchecked());
             }
-        };
-        // We need to remove our claim
-        if selector_or_resource_changed_claim {
-            info!("Selector or resource changed, claim has been updated!");
-            status.claim = None;
         }
 
-        // Find new claim, it's possible it'll match the existing
-        // association, in which case, we won't disassociate
-        if status.claim.is_none() {
+        // Check to make sure our resource still matches
+        // incase our selectors have updated, or the nodes/pods have changed
+        let mut disassociate = false;
+        match &eip.spec.selector {
+            EipSelector::Pod { pod_name: _ } => {
+                if matched_pods.is_empty() {
+                    disassociate = true;
+                }
+            }
+            EipSelector::Node { selector: _ } => {
+                disassociate = true;
+                for node in &matched_nodes {
+                    if eip.associated_with_node(node) {
+                        disassociate = false;
+                        break;
+                    }
+                }
+            }
+        };
+
+        // Disassociaate if conditions are met
+        if disassociate {
+            info!("Disassociating EIP! {}", name);
+            let association_id = match addresses.len() {
+                0 => Ok(None),
+                1 => Ok(addresses[0].association_id().map(|id| id.to_owned())),
+                _ => Err(Error::MultipleAddressesAssociatedToEip),
+            }?;
+
+            if let Some(id) = association_id {
+                crate::aws::disassociate_eip(&self.ec2_client, &id).await?;
+            } else {
+                info!("EIP {} was already disassociated", name);
+            }
+            status.eni = None;
+            status.private_ip_address = None;
+            crate::eip::update_status(&eip_api, name, &status).await?;
+        }
+
+        // Find new resource to associate with there is no current claim
+        let mut associatiate_with_ip: Option<&str> = None;
+        let mut associatiate_with_node: Option<Node> = None;
+        if !eip.attached() {
             match eip.spec.selector {
                 EipSelector::Node { selector: _ } => match matched_nodes.len() {
                     0 => {
                         warn!("Eip {} matches no nodes", name);
                     }
-                    1 => {
-                        let node_name = matched_nodes[0]
-                            .metadata
-                            .name
-                            .clone()
-                            .ok_or(Error::MissingNodeName)?;
-                        info!("Eip {} matches node {}, updating claim", name, node_name,);
-                        status.claim = Some(node_name);
-                    }
                     _ => {
-                        warn!(
-                            "Eip {} matches multiple nodes - {}, choosing the first",
-                            name,
-                            matched_nodes
-                                .iter()
-                                .map(|node| { node.metadata.name.clone().unwrap_or_default() })
-                                .collect::<Vec<String>>()
-                                .join(",")
-                        );
-                        let node_name = matched_nodes[0]
-                            .metadata
-                            .name
-                            .clone()
-                            .ok_or(Error::MissingNodeName)?;
-                        info!("Eip {} matches node {}, updating claim", name, node_name,);
-                        status.claim = Some(node_name);
+                        let node_name = matched_nodes[0].name_unchecked();
+                        info!("Eip {} matches node {}, updating", name, node_name,);
+                        associatiate_with_node = Some(matched_nodes[0].clone());
+                        associatiate_with_ip =
+                            Some(matched_nodes[0].ip().ok_or(Error::MissingNodeIp)?);
+                        if matched_nodes.len() > 1 {
+                            warn!(
+                                "Eip {} matches multiple nodes - {}, choosing the first",
+                                name,
+                                matched_nodes
+                                    .iter()
+                                    .map(|node| node.name_unchecked())
+                                    .collect::<Vec<String>>()
+                                    .join(",")
+                            );
+                        }
                     }
                 },
                 EipSelector::Pod { pod_name: _ } => match matched_pods.len() {
@@ -203,21 +211,26 @@ impl k8s_controller::Context for Context {
                     }
                     1 => {
                         info!(
-                            "Eip {} matches pod {}, updating claim",
+                            "Eip {} matches pod {}, updating",
                             name,
-                            matched_pods[0]
-                                .metadata
-                                .name
-                                .clone()
-                                .ok_or(Error::MissingPodName)?,
+                            matched_pods[0].name_unchecked()
                         );
-                        status.claim = Some(
-                            matched_pods[0]
-                                .metadata
-                                .name
-                                .clone()
-                                .ok_or(Error::MissingPodName)?,
-                        );
+                        let node = node_api
+                            .get_opt(
+                                matched_pods[0]
+                                    .node_name()
+                                    .ok_or(Error::MissingPodNodeName)?,
+                            )
+                            .await?
+                            .ok_or(Error::MissingNode)?;
+                        associatiate_with_node = Some(node);
+                        if let Some(ip) = matched_pods[0].ip() {
+                            associatiate_with_ip = Some(ip);
+                        } else {
+                            // This is a case where we've found a pod but it has yet to be
+                            // scheduled, we need to retry
+                            return Ok(Some(Action::requeue(Duration::from_secs(1))));
+                        }
                     }
                     _ => {
                         error!(
@@ -225,7 +238,7 @@ impl k8s_controller::Context for Context {
                             name,
                             matched_pods
                                 .iter()
-                                .map(|pod| { pod.metadata.name.clone().unwrap_or_default() })
+                                .map(|pod| pod.name_unchecked())
                                 .collect::<Vec<String>>()
                                 .join(",")
                         );
@@ -234,109 +247,26 @@ impl k8s_controller::Context for Context {
             }
         }
 
-        // TODO (jubrad)
-        // This code should handle migration to claims
-        // a bit more elegantly, it can be removed after all
-        // eips are using claims.
-        // We want to avoid disassociate/reassociate
-        // in the case that an eip prior to the introduction
-        // of claims is correctly associated without a claim
-        let mut correctly_associated_but_originally_unclaimed: bool = false;
-        if eip.attached() && originally_unclaimed && status.claim.is_some() {
-            let claim = status.claim.clone().unwrap();
-            correctly_associated_but_originally_unclaimed = match &eip.spec.selector {
-                EipSelector::Node { selector: _ } => {
-                    status.private_ip_address.as_deref()
-                        == node_api
-                            .get_opt(&claim)
-                            .await?
-                            .ok_or(Error::MissingNode)?
-                            .ip()
-                }
-                EipSelector::Pod { pod_name: _ } => {
-                    status.private_ip_address.as_deref()
-                        == pod_api
-                            .get_opt(&claim)
-                            .await?
-                            .ok_or(Error::MissingPod)?
-                            .ip()
-                }
-            };
-        };
-
-        // Disassociaate if conditions are met
-        if eip.attached()
-            && (status.claim.is_none()
-                || (selector_or_resource_changed_claim
-                    && !correctly_associated_but_originally_unclaimed))
-        {
-            info!("Disassociating EIP! {}", name);
-            let association_id = eip.association_id(&self.ec2_client).await?;
-            if let Some(id) = association_id {
-                crate::aws::disassociate_eip(&self.ec2_client, &id).await?;
-            } else {
-                info!("EIP {} was already disassociated", name);
+        match (associatiate_with_node, associatiate_with_ip) {
+            (Some(node), Some(ip)) => {
+                status.eni = Some(
+                    eip.associate_with_node_and_ip(&self.ec2_client, &node, ip)
+                        .await?,
+                );
+                status.private_ip_address = Some(ip.to_owned());
+                info!(
+                    "Eip {} has been successfully associated after reconciliation",
+                    eip.name().unwrap()
+                );
             }
-            status.eni = None;
-            status.private_ip_address = None;
+            (None, None) => {
+                info!("Eip {} is correctly associated!", eip.name_unchecked());
+            }
+            (_, _) => {
+                // this should not be possible
+                error!("Bad state, need both node and eip to associate");
+            }
         }
-
-        // Associate if claimed and not attached
-        if status.claim.is_some() && !eip.attached() {
-            info!("Associating EIP! {}", name);
-            let claim = status.claim.clone().unwrap();
-            // find the node and ip to associate
-            let (node, ip) = match &eip.spec.selector {
-                EipSelector::Node { selector: _ } => {
-                    let node = node_api.get_opt(&claim).await?.ok_or(Error::MissingNode)?;
-                    let node_ip = node.ip().ok_or(Error::MissingNodeIp)?;
-                    (node.to_owned(), node_ip.to_owned())
-                }
-                EipSelector::Pod { pod_name: _ } => {
-                    let pod = pod_api.get_opt(&claim).await?.ok_or(Error::MissingPod)?;
-                    let node_name = pod.node_name();
-                    if node_name.is_none() {
-                        warn!(
-                            "Pod {} does not yet have a node assigned- Rescheduling",
-                            pod.metadata.name.ok_or(Error::MissingPodName)?
-                        );
-                        return Ok(Some(Action::requeue(Duration::from_secs(1))));
-                    }
-                    let node = node_api
-                        .get_opt(node_name.unwrap())
-                        .await?
-                        .ok_or(Error::MissingNode)?;
-                    let pod_ip = pod.ip();
-                    if pod_ip.is_none() {
-                        warn!(
-                            "Pod {} does not have a ip assigned - Rescheduling",
-                            pod.metadata.name.ok_or(Error::MissingPodName)?
-                        );
-                        return Ok(Some(Action::requeue(Duration::from_secs(1))));
-                    }
-                    (node, pod_ip.unwrap().to_owned())
-                }
-            };
-            // attach to node
-            let provider_id = node.provider_id().ok_or(Error::MissingProviderId)?;
-            let instance_id = provider_id
-                .rsplit_once('/')
-                .ok_or(Error::MalformedProviderId)?
-                .1;
-            let instance_description =
-                crate::aws::describe_instance(&self.ec2_client, instance_id).await?;
-            let allocation_id = status
-                .allocation_id
-                .clone()
-                .ok_or(Error::MissingAllocationId)?;
-            let eni_id = crate::aws::get_eni_from_private_ip(&instance_description, &ip)
-                .ok_or(Error::NoInterfaceWithThatIp)?;
-            crate::aws::associate_eip(&self.ec2_client, &allocation_id, &eni_id, &ip).await?;
-            status.eni = Some(eni_id);
-            status.private_ip_address = Some(ip.to_owned());
-        }
-
-        // Ensure status is up-to-date
         if eip.status != Some(status.clone()) {
             crate::eip::update_status(&eip_api, name, &status).await?;
         }

--- a/eip_operator/src/controller/eip.rs
+++ b/eip_operator/src/controller/eip.rs
@@ -246,7 +246,7 @@ impl k8s_controller::Context for Context {
             let claim = status.claim.clone().unwrap();
             correctly_associated_but_originally_unclaimed = match &eip.spec.selector {
                 EipSelector::Node { selector: _ } => {
-                    status.private_ip_address.as_ref().map(|ip| ip.as_str())
+                    status.private_ip_address.as_deref()
                         == node_api
                             .get_opt(&claim)
                             .await?
@@ -254,7 +254,7 @@ impl k8s_controller::Context for Context {
                             .ip()
                 }
                 EipSelector::Pod { pod_name: _ } => {
-                    status.private_ip_address.as_ref().map(|ip| ip.as_str())
+                    status.private_ip_address.as_deref()
                         == pod_api
                             .get_opt(&claim)
                             .await?

--- a/eip_operator/src/controller/eip.rs
+++ b/eip_operator/src/controller/eip.rs
@@ -1,13 +1,16 @@
 use std::collections::HashMap;
 
-use kube::api::Api;
-use kube::{Client, ResourceExt};
+use k8s_openapi::api::core::v1::{Node, Pod};
+use kube::api::{Api, ListParams};
+use kube::Client;
 use kube_runtime::controller::Action;
 use tracing::instrument;
+use tracing::{info, warn};
 
 use eip_operator_shared::Error;
 
-use crate::eip::v2::Eip;
+use crate::eip::v2::{Eip, EipSelector};
+use crate::kube_ext::{NodeExt, PodExt};
 
 pub(crate) struct Context {
     ec2_client: aws_sdk_ec2::Client,
@@ -42,11 +45,16 @@ impl k8s_controller::Context for Context {
         client: Client,
         eip: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
-        let eip_api = Api::namespaced(client, &eip.namespace().unwrap());
+        let eip_api = Api::namespaced(client.clone(), eip.namespace().unwrap());
+        let pod_api = Api::<Pod>::namespaced(client.clone(), eip.namespace().unwrap());
+        let node_api = Api::<Node>::all(client.clone());
 
+        // Ensure EIP is Created
         let uid = eip.metadata.uid.as_ref().ok_or(Error::MissingEipUid)?;
         let name = eip.metadata.name.as_ref().ok_or(Error::MissingEipName)?;
         let selector = &eip.spec.selector;
+        let mut status = eip.status.clone().unwrap_or_default();
+
         let addresses = crate::aws::describe_addresses_with_tag_value(
             &self.ec2_client,
             crate::aws::EIP_UID_TAG,
@@ -55,7 +63,7 @@ impl k8s_controller::Context for Context {
         .await?
         .addresses
         .ok_or(Error::MissingAddresses)?;
-        let (allocation_id, public_ip) = match addresses.len() {
+        let allocation_id = match addresses.len() {
             0 => {
                 let response = crate::aws::allocate_address(
                     &self.ec2_client,
@@ -63,13 +71,15 @@ impl k8s_controller::Context for Context {
                     name,
                     selector,
                     &self.cluster_name,
-                    &eip.namespace().unwrap(),
+                    eip.namespace().unwrap(),
                     &self.default_tags,
                 )
                 .await?;
                 let allocation_id = response.allocation_id.ok_or(Error::MissingAllocationId)?;
                 let public_ip = response.public_ip.ok_or(Error::MissingPublicIp)?;
-                (allocation_id, public_ip)
+                status.allocation_id = Some(allocation_id.clone());
+                status.public_ip_address = Some(public_ip);
+                allocation_id
             }
             1 => {
                 let allocation_id = addresses[0]
@@ -80,13 +90,149 @@ impl k8s_controller::Context for Context {
                     .public_ip
                     .as_ref()
                     .ok_or(Error::MissingPublicIp)?;
-                (allocation_id.to_owned(), public_ip.to_owned())
+                status.allocation_id = Some(allocation_id.clone());
+                status.public_ip_address = Some(public_ip.clone());
+                allocation_id.to_owned()
             }
             _ => {
                 return Err(Error::MultipleEipsTaggedForPod);
             }
         };
-        crate::eip::set_status_created(&eip_api, name, &allocation_id, &public_ip).await?;
+
+        // disassociate if unclaimed or if claimed and the node / pod terminating
+        let mut disassociate = status.claim.is_none();
+        if let Some(claim) = status.claim.clone() {
+            match &eip.spec.selector {
+                EipSelector::Node { selector: _ } => {
+                    if let Some(node) = node_api.get_opt(&claim.clone()).await? {
+                        disassociate = node.metadata.deletion_timestamp.is_some();
+                    }
+                }
+                EipSelector::Pod { pod_name: _ } => {
+                    if let Some(pod) = pod_api.get_opt(&claim.clone()).await? {
+                        disassociate = pod.metadata.deletion_timestamp.is_some()
+                    }
+                }
+            }
+        }
+        if disassociate {
+            crate::aws::disassociate_eip(&self.ec2_client, &allocation_id).await?;
+            status.claim = None;
+            status.eni = None;
+            status.private_ip_address = None;
+        }
+
+        // search for new resource to be claimed by
+        match eip.spec.selector {
+            EipSelector::Node { selector: _ } => {
+                let nodes: Vec<Node> = node_api
+                    .list(&ListParams::default())
+                    .await?
+                    .into_iter()
+                    .filter(|node| eip.matches_node(node))
+                    .collect();
+                match nodes.len() {
+                    0 => {
+                        warn!("Eip {} matches no nodes", name);
+                    }
+                    1 => {
+                        let node_name = nodes[0]
+                            .metadata
+                            .name
+                            .clone()
+                            .ok_or(Error::MissingNodeName)?;
+                        info!("Eip {} matches node {}, updating claim", name, node_name,);
+                        status.claim = Some(node_name);
+                    }
+                    _ => {
+                        warn!(
+                            "Eip {} matches multiple nodes - {}",
+                            name,
+                            nodes
+                                .iter()
+                                .map(|node| { node.metadata.name.clone().unwrap_or_default() })
+                                .collect::<Vec<String>>()
+                                .join(",")
+                        );
+                    }
+                }
+            }
+            EipSelector::Pod { pod_name: _ } => {
+                let pods: Vec<Pod> = pod_api
+                    .list(&ListParams::default())
+                    .await?
+                    .into_iter()
+                    .filter(|pod| eip.matches_pod(pod))
+                    .collect();
+                match pods.len() {
+                    0 => {
+                        warn!("Eip {} matches no pods", name);
+                    }
+                    1 => {
+                        info!(
+                            "Eip {} matches pod {}, updating claim",
+                            name,
+                            pods[0].metadata.name.clone().ok_or(Error::MissingPodName)?,
+                        );
+                        status.claim =
+                            Some(pods[0].metadata.name.clone().ok_or(Error::MissingPodName)?);
+                    }
+                    _ => {
+                        info!(
+                            "Eip {} matches multiple pods - {}",
+                            name,
+                            pods.iter()
+                                .map(|pod| { pod.metadata.name.clone().unwrap_or_default() })
+                                .collect::<Vec<String>>()
+                                .join(",")
+                        );
+                    }
+                }
+            }
+        }
+
+        // Associate if claimed
+        if status.claim.is_some() && !eip.attached() {
+            let claim = status.claim.clone().unwrap();
+            let (node, ip) = match &eip.spec.selector {
+                EipSelector::Node { selector: _ } => {
+                    let node = node_api.get_opt(&claim).await?.ok_or(Error::MissingNode)?;
+                    let node_ip = node.ip().ok_or(Error::MissingNodeIp)?;
+                    (node.to_owned(), node_ip.to_owned())
+                }
+                EipSelector::Pod { pod_name: _ } => {
+                    let pod = pod_api.get_opt(&claim).await?.ok_or(Error::MissingPod)?;
+                    let node_name = pod.node_name().ok_or(Error::MissingNodeName)?;
+                    let node = node_api
+                        .get_opt(node_name)
+                        .await?
+                        .ok_or(Error::MissingNode)?;
+                    let pod_ip = pod.ip().ok_or(Error::MissingPodIp)?;
+                    (node, pod_ip.to_owned())
+                }
+            };
+            // attach to node
+            let provider_id = node.provider_id().ok_or(Error::MissingProviderId)?;
+            let instance_id = provider_id
+                .rsplit_once('/')
+                .ok_or(Error::MalformedProviderId)?
+                .1;
+            let instance_description =
+                crate::aws::describe_instance(&self.ec2_client, instance_id).await?;
+            let allocation_id = status
+                .allocation_id
+                .clone()
+                .ok_or(Error::MissingAllocationId)?;
+            let eni_id = crate::aws::get_eni_from_private_ip(&instance_description, &ip)
+                .ok_or(Error::NoInterfaceWithThatIp)?;
+            crate::aws::associate_eip(&self.ec2_client, &allocation_id, &eni_id, &ip).await?;
+            status.eni = Some(eni_id);
+            status.private_ip_address = Some(ip.to_owned());
+        }
+
+        if eip.status != Some(status.clone()) {
+            crate::eip::update_status(&eip_api, name, &status).await?;
+        }
         Ok(None)
     }
 

--- a/eip_operator/src/controller/node.rs
+++ b/eip_operator/src/controller/node.rs
@@ -1,13 +1,14 @@
+use std::time::Duration;
+
 use k8s_openapi::api::core::v1::Node;
 use kube::api::{Api, ListParams};
-use kube::Client;
+use kube::{Client, ResourceExt};
 use kube_runtime::controller::Action;
 use tracing::{event, info, instrument, Level};
 
 use eip_operator_shared::Error;
 
 use crate::eip::v2::Eip;
-use crate::kube_ext::NodeExt;
 
 pub(crate) struct Context {
     namespace: Option<String>,
@@ -38,36 +39,76 @@ impl k8s_controller::Context for Context {
             client.clone(),
             self.namespace.as_deref().unwrap_or("default"),
         );
-        // Find an EIP and claim if not claimed
-        let node_labels = node.labels().ok_or(Error::MissingNodeLabels)?;
-        let eip = eip_api
-            .list(&ListParams::default())
-            .await?
-            .items
-            .into_iter()
-            .find(|eip| eip.matches_node_labels(node_labels) && eip.status.is_some())
-            .ok_or(Error::NoEipResourceWithThatNodeSelector)?;
-        let eip_name = eip.name().ok_or(Error::MissingEipName)?;
-
-        // Claim it if unclaimed
-        if !eip.claimed() {
-            let _allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
-            crate::eip::set_status_claimed(&eip_api, eip_name, name).await?;
-            Ok(None)
-        } else {
-            if eip.claimed_by(name) {
-                info!(
-                    "Found EIP {} already appropriately claimed by node {}",
-                    eip_name, name,
-                );
+        let node_labels = node.labels();
+        let eips = eip_api.list(&ListParams::default()).await?.items;
+        // Cases
+        // there are some eips
+        // - we are associated with one
+        //   - it is correct
+        //     - done - register dns labels - ok
+        //   - it is incorrect
+        //     - ask eip to reoncile, reschedule
+        // - we are not associated with any
+        //   - we want to be
+        //     - an eip is not associated (potentially free to grab)
+        //       - we ask to claim it
+        //     - it is associated (someone else is using it)
+        //       - done ok
+        //   - we do not want to be
+        //     - done ok
+        // no eips
+        // - done ok
+        if !eips.is_empty() {
+            // there are eips
+            if let Some(eip) = eips.iter().find(|eip| eip.associated_with_node(node)) {
+                // we are associated with an eip
+                if eip.matches_node_labels(node_labels) {
+                    // we are associated and it is correct
+                    info!(
+                        "Node {} is already attached to EIP {}",
+                        node.name_unchecked(),
+                        eip.name_unchecked()
+                    );
+                    return Ok(None);
+                } else {
+                    // we are associated and it is incorrect
+                    info!(
+                        "Node {} is attached to EIP {}, but should not be, asking eip to reconcile",
+                        node.name_unchecked(),
+                        eip.name_unchecked()
+                    );
+                    crate::eip::trigger_reconciliation(&eip_api, &eip.name_unchecked()).await?;
+                    return Ok(None);
+                }
             } else {
-                info!(
-                    "Found EIP {} matching node {}, but claimed by {}",
-                    eip_name,
-                    name,
-                    eip.claim().ok_or(Error::MissingEipClaim)?
-                );
+                // we are not associated
+                if let Some(eip) = eips
+                    .iter()
+                    .find(|eip| eip.matches_node_labels(node_labels) && !eip.attached())
+                {
+                    // we have an eip we want to associate with
+                    info!(
+                        "Node {} found a matching unattached EIP {}, asking it to reconcile",
+                        node.name_unchecked(),
+                        eip.name_unchecked()
+                    );
+                    crate::eip::trigger_reconciliation(&eip_api, &eip.name_unchecked()).await?;
+                    Ok(None)
+                } else {
+                    // There are no eips we want to associate with or none are free
+                    info!(
+                        "No matching unattached EIPs for Node {}",
+                        node.name_unchecked()
+                    );
+                    return Ok(None);
+                }
             }
+        } else {
+            // there are no eips
+            info!(
+                "No matching unattached EIPs for Node {}",
+                node.name_unchecked()
+            );
             return Ok(None);
         }
     }
@@ -79,7 +120,6 @@ impl k8s_controller::Context for Context {
         node: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
         // remove claim if one exists
-        let name = node.metadata.name.as_ref().ok_or(Error::MissingNodeName)?;
         let eip_api = Api::<Eip>::namespaced(
             client.clone(),
             self.namespace.as_deref().unwrap_or("default"),
@@ -89,12 +129,41 @@ impl k8s_controller::Context for Context {
             .await?
             .items
             .into_iter()
-            .filter(|eip| eip.attached())
-            .find(|eip| eip.claimed_by(name));
+            .find(|eip| eip.associated_with_node(node));
         if let Some(eip) = eip {
-            crate::eip::set_status_unclaimed(&eip_api, eip.name().ok_or(Error::MissingEipName)?)
-                .await?;
+            info!(
+                "Node {} still attached to EIP {}, asking eip to re-reconcile",
+                node.name_unchecked(),
+                eip.name_unchecked()
+            );
+            crate::eip::trigger_reconciliation(&eip_api, &eip.name_unchecked()).await?;
+            for _ in 0..5 {
+                let eip = eip_api.get_opt(&eip.name_unchecked()).await?;
+                if let Some(eip) = eip {
+                    if !eip.associated_with_node(node) {
+                        info!(
+                            "Node {} has been disassociated with EIP {}",
+                            node.name_unchecked(),
+                            eip.name_unchecked()
+                        );
+                        return Ok(None);
+                    }
+                } else {
+                    info!(
+                        "Node {} no longer has an attached eip",
+                        node.name_unchecked()
+                    );
+                    return Ok(None);
+                }
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+            Err(Error::NodeFailedToRemoveEip)
+        } else {
+            info!(
+                "Node {} is not attached to any EIP, cleanup successful",
+                node.name_unchecked()
+            );
+            Ok(None)
         }
-        Ok(None)
     }
 }

--- a/eip_operator/src/controller/node.rs
+++ b/eip_operator/src/controller/node.rs
@@ -2,7 +2,7 @@ use k8s_openapi::api::core::v1::Node;
 use kube::api::{Api, ListParams};
 use kube::Client;
 use kube_runtime::controller::Action;
-use tracing::{event, instrument, Level};
+use tracing::{event, info, instrument, Level};
 
 use eip_operator_shared::Error;
 
@@ -10,16 +10,12 @@ use crate::eip::v2::Eip;
 use crate::kube_ext::NodeExt;
 
 pub(crate) struct Context {
-    ec2_client: aws_sdk_ec2::Client,
     namespace: Option<String>,
 }
 
 impl Context {
-    pub(crate) fn new(ec2_client: aws_sdk_ec2::Client, namespace: Option<String>) -> Self {
-        Self {
-            ec2_client,
-            namespace,
-        }
+    pub(crate) fn new(namespace: Option<String>) -> Self {
+        Self { namespace }
     }
 }
 
@@ -36,45 +32,32 @@ impl k8s_controller::Context for Context {
         client: Client,
         node: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
+        // Find an EIP and claim if not claimed
         let name = node.metadata.name.as_ref().ok_or(Error::MissingNodeName)?;
         event!(Level::INFO, name = %name, "Applying node.");
-
         let eip_api = Api::<Eip>::namespaced(
             client.clone(),
             self.namespace.as_deref().unwrap_or("default"),
         );
-
-        let node_ip = node.ip().ok_or(Error::MissingNodeIp)?;
         let node_labels = node.labels().ok_or(Error::MissingNodeLabels)?;
-        let provider_id = node.provider_id().ok_or(Error::MissingProviderId)?;
-        let instance_id = provider_id
-            .rsplit_once('/')
-            .ok_or(Error::MalformedProviderId)?
-            .1;
         let all_eips = eip_api.list(&ListParams::default()).await?.items;
         let eip = all_eips
             .into_iter()
-            .find(|eip| eip.matches_node(node_labels))
+            .find(|eip| eip.matches_node_labels(node_labels) && eip.status.is_some())
             .ok_or(Error::NoEipResourceWithThatNodeSelector)?;
+        // do nothing if eip already claimed
         let eip_name = eip.name().ok_or(Error::MissingEipName)?;
-        let allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
-        let eip_description = crate::aws::describe_address(&self.ec2_client, allocation_id)
-            .await?
-            .addresses
-            .ok_or(Error::MissingAddresses)?
-            .swap_remove(0);
-        let instance_description =
-            crate::aws::describe_instance(&self.ec2_client, instance_id).await?;
-
-        let eni_id = crate::aws::get_eni_from_private_ip(&instance_description, node_ip)
-            .ok_or(Error::NoInterfaceWithThatIp)?;
-        if eip_description.network_interface_id != Some(eni_id.to_owned())
-            || eip_description.private_ip_address != Some(node_ip.to_owned())
-        {
-            crate::aws::associate_eip(&self.ec2_client, allocation_id, &eni_id, node_ip).await?;
-        }
-        crate::eip::set_status_attached(&eip_api, eip_name, &eni_id, node_ip).await?;
-
+        if eip.claimed() {
+            info!(
+                "Found claimed ip {} matching node {}, skipping",
+                eip_name, name,
+            );
+            return Ok(None);
+        };
+        let eip_name = eip.name().ok_or(Error::MissingEipName)?;
+        // ensure there's an allocation id before claiming
+        let _allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
+        crate::eip::set_status_claimed(&eip_api, eip_name, name).await?;
         Ok(None)
     }
 
@@ -84,33 +67,20 @@ impl k8s_controller::Context for Context {
         client: Client,
         node: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
+        // remove claim
         let eip_api = Api::<Eip>::namespaced(
             client.clone(),
             self.namespace.as_deref().unwrap_or("default"),
         );
-
         let node_labels = node.labels().ok_or(Error::MissingNodeLabels)?;
         let all_eips = eip_api.list(&ListParams::default()).await?.items;
         let eip = all_eips
             .into_iter()
             .filter(|eip| eip.attached())
-            .find(|eip| eip.matches_node(node_labels));
+            .find(|eip| eip.matches_node_labels(node_labels));
         if let Some(eip) = eip {
-            let allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
-            let addresses = crate::aws::describe_address(&self.ec2_client, allocation_id)
-                .await?
-                .addresses
-                .ok_or(Error::MissingAddresses)?;
-            for address in addresses {
-                if let Some(association_id) = address.association_id {
-                    crate::aws::disassociate_eip(&self.ec2_client, &association_id).await?;
-                }
-            }
-            crate::eip::set_status_detached(
-                &eip_api,
-                eip.metadata.name.as_ref().ok_or(Error::MissingEipName)?,
-            )
-            .await?;
+            crate::eip::set_status_detached(&eip_api, eip.name().ok_or(Error::MissingEipName)?)
+                .await?;
         }
         Ok(None)
     }

--- a/eip_operator/src/controller/pod.rs
+++ b/eip_operator/src/controller/pod.rs
@@ -1,14 +1,12 @@
-use k8s_openapi::api::core::v1::{Node, Pod};
+use k8s_openapi::api::core::v1::Pod;
 use kube::api::{Api, ListParams, Patch, PatchParams};
 use kube::{Client, ResourceExt};
 use kube_runtime::controller::Action;
-use serde::Deserialize;
 use tracing::{event, instrument, Level};
 
 use eip_operator_shared::Error;
 
 use crate::eip::v2::Eip;
-use crate::kube_ext::{NodeExt, PodExt};
 
 pub(crate) struct Context {
     ec2_client: aws_sdk_ec2::Client,
@@ -33,45 +31,24 @@ impl k8s_controller::Context for Context {
         client: Client,
         pod: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
+        // find matching eip and claim, create it if should autocreate
         let name = pod.metadata.name.as_ref().ok_or(Error::MissingPodName)?;
-
         let eip_api = Api::<Eip>::namespaced(client.clone(), &pod.namespace().unwrap());
         let pod_api = Api::<Pod>::namespaced(client.clone(), &pod.namespace().unwrap());
-        let node_api = Api::<Node>::all(client.clone());
 
+        // create eip if should auto-create
         if should_autocreate_eip(pod) {
             event!(Level::INFO, should_autocreate_eip = true);
             crate::eip::create_for_pod(&eip_api, name).await?;
         }
 
-        let pod_ip = pod.ip().ok_or(Error::MissingPodIp)?;
-        let node_name = pod.node_name().ok_or(Error::MissingNodeName)?;
-
-        let node = node_api.get(node_name).await?;
-
-        let provider_id = node.provider_id().ok_or(Error::MissingProviderId)?;
-        let instance_id = provider_id
-            .rsplit_once('/')
-            .ok_or(Error::MalformedProviderId)?
-            .1;
-
-        let eni_id = match get_eni_id_from_annotation(pod) {
-            Some(eni_id) => eni_id,
-            None => {
-                let instance_description =
-                    crate::aws::describe_instance(&self.ec2_client, instance_id).await?;
-
-                crate::aws::get_eni_from_private_ip(&instance_description, pod_ip)
-                    .ok_or(Error::NoInterfaceWithThatIp)?
-            }
-        };
-
         let all_eips = eip_api.list(&ListParams::default()).await?.items;
         let eip = all_eips
             .into_iter()
-            .find(|eip| eip.matches_pod(name))
+            .find(|eip| eip.matches_pod(pod))
             .ok_or_else(|| Error::NoEipResourceWithThatPodName(name.to_owned()))?;
         let eip_name = eip.name().ok_or(Error::MissingEipName)?;
+        crate::eip::set_status_claimed(&eip_api, eip_name, name).await?;
         let allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
         let eip_description = crate::aws::describe_address(&self.ec2_client, allocation_id)
             .await?
@@ -79,12 +56,6 @@ impl k8s_controller::Context for Context {
             .ok_or(Error::MissingAddresses)?
             .swap_remove(0);
         let public_ip = eip_description.public_ip.ok_or(Error::MissingPublicIp)?;
-        if eip_description.network_interface_id != Some(eni_id.to_owned())
-            || eip_description.private_ip_address != Some(pod_ip.to_owned())
-        {
-            crate::aws::associate_eip(&self.ec2_client, allocation_id, &eni_id, pod_ip).await?;
-        }
-        crate::eip::set_status_attached(&eip_api, eip_name, &eni_id, pod_ip).await?;
         add_dns_target_annotation(&pod_api, name, &public_ip, allocation_id).await?;
         Ok(None)
     }
@@ -95,33 +66,17 @@ impl k8s_controller::Context for Context {
         client: Client,
         pod: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
+        // remove claim, delete if autocreate
         let name = pod.metadata.name.as_ref().ok_or(Error::MissingPodUid)?;
-
         let eip_api = Api::<Eip>::namespaced(client.clone(), &pod.namespace().unwrap());
-
         let all_eips = eip_api.list(&ListParams::default()).await?.items;
-        let eip = all_eips.into_iter().find(|eip| eip.matches_pod(name));
-        if let Some(eip) = eip {
-            let allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
-            let addresses = crate::aws::describe_address(&self.ec2_client, allocation_id)
-                .await?
-                .addresses
-                .ok_or(Error::MissingAddresses)?;
-            for address in addresses {
-                if let Some(association_id) = address.association_id {
-                    crate::aws::disassociate_eip(&self.ec2_client, &association_id).await?;
-                }
-            }
-            crate::eip::set_status_detached(
-                &eip_api,
-                eip.metadata.name.as_ref().ok_or(Error::MissingEipName)?,
-            )
-            .await?;
-        };
-        if should_autocreate_eip(pod) {
+        let eip = all_eips.into_iter().find(|eip| eip.matches_pod(pod));
+        if should_autocreate_eip(pod) && eip.is_some() {
             event!(Level::INFO, should_autocreate_eip = true);
-            crate::eip::delete(&eip_api, name).await?;
-        }
+            crate::eip::delete(&eip_api, eip.unwrap().name().ok_or(Error::MissingEipName)?).await?;
+        } else {
+            crate::eip::set_status_detached(&eip_api, name).await?;
+        };
         Ok(None)
     }
 }
@@ -139,36 +94,6 @@ fn should_autocreate_eip(pod: &Pod) -> bool {
         .unwrap_or("false")
         .to_lowercase()
         == "true"
-}
-
-/// Parse the vpc.amazonaws.com/pod-eni annotation if it exists, and return the ENI ID.
-#[instrument(skip(pod))]
-fn get_eni_id_from_annotation(pod: &Pod) -> Option<String> {
-    event!(Level::INFO, "Getting ENI ID from annotation.");
-    let annotation = pod
-        .metadata
-        .annotations
-        .as_ref()?
-        .get("vpc.amazonaws.com/pod-eni")?;
-    event!(Level::INFO, annotation = %annotation);
-
-    /// An annotation attached to a pod by EKS describing the branch network
-    /// interfaces when using per-pod security groups.
-    /// example: [{
-    ///     "eniId":"eni-0e42914a33ee3c5ce",
-    ///     "ifAddress":"0e:cb:3c:0d:97:3b",
-    ///     "privateIp":"10.1.191.190",
-    ///     "vlanId":1,
-    ///     "subnetCidr":"10.1.160.0/19"
-    /// }]
-    #[derive(Debug, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct EniDescription {
-        eni_id: String,
-    }
-    let eni_descriptions: Vec<EniDescription> = serde_json::from_str(annotation).ok()?;
-
-    Some(eni_descriptions.first()?.eni_id.to_owned())
 }
 
 /// Applies annotation to pod specifying the target IP for external-dns.

--- a/eip_operator/src/controller/pod.rs
+++ b/eip_operator/src/controller/pod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::{Api, ListParams, Patch, PatchParams};
 use kube::{Client, ResourceExt};
@@ -41,43 +43,78 @@ impl k8s_controller::Context for Context {
             event!(Level::INFO, should_autocreate_eip = true);
             crate::eip::create_for_pod(&eip_api, name).await?;
         }
-
-        // Find an eip to claim
-        let eip = eip_api
-            .list(&ListParams::default())
-            .await?
-            .items
-            .into_iter()
-            .find(|eip| eip.matches_pod(pod))
-            .ok_or_else(|| Error::NoEipResourceWithThatPodName(name.to_owned()))?;
-        let eip_name = eip.name().ok_or(Error::MissingEipName)?;
-
-        // Claim it if unclaimed
-        let mut claimed_here = false;
-        if !eip.claimed() {
-            crate::eip::set_status_claimed(&eip_api, eip_name, name).await?;
-            claimed_here = true;
-        }
-        // Setup if claimed, otherwise log
-        if eip.claimed_by(name) || claimed_here {
-            let allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
-            let eip_description = crate::aws::describe_address(&self.ec2_client, allocation_id)
-                .await?
-                .addresses
-                .ok_or(Error::MissingAddresses)?
-                .swap_remove(0);
-            let public_ip = eip_description.public_ip.ok_or(Error::MissingPublicIp)?;
-            add_dns_target_annotation(&pod_api, name, &public_ip, allocation_id).await?;
+        let eips = eip_api.list(&ListParams::default()).await?.items;
+        // Cases
+        // there are some eips
+        // - we are associated with one
+        //   - it is correct
+        //     - done - register dns labels - ok
+        //   - it is incorrect
+        //     - ask eip to reoncile, reschedule
+        // - we are not associated with any
+        //   - we want to be
+        //     - an eip is not associated (potentially free to grab)
+        //       - we ask to claim it
+        //     - it is associated (someone else is using it)
+        //       - done ok
+        //   - we do not want to be
+        //     - done ok
+        // no eips
+        // - done ok
+        if !eips.is_empty() {
+            // there are eips
+            if let Some(eip) = eips.iter().find(|eip| eip.associated_with_pod(pod)) {
+                // we are associated with an eip
+                if eip.matches_pod_name(&pod.name_unchecked()) {
+                    // we are associated, it is correct
+                    info!(
+                        "Pod {} is already attached to EIP {}, setting up DNS target annotation",
+                        pod.name_unchecked(),
+                        eip.name_unchecked()
+                    );
+                    let allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
+                    let eip_description =
+                        crate::aws::describe_address(&self.ec2_client, allocation_id)
+                            .await?
+                            .addresses
+                            .ok_or(Error::MissingAddresses)?
+                            .swap_remove(0);
+                    let public_ip = eip_description.public_ip.ok_or(Error::MissingPublicIp)?;
+                    add_dns_target_annotation(&pod_api, name, &public_ip, allocation_id).await?;
+                    return Ok(None);
+                } else {
+                    // we are associated, it is incorrect
+                    info!("Pod {} is attached to EIP {}, but should not be, asking eip to reconcile, and rescheduling reconciliation", pod.name_unchecked(), eip.name_unchecked());
+                    crate::eip::trigger_reconciliation(&eip_api, &eip.name_unchecked()).await?;
+                    return Ok(Some(Action::requeue(Duration::from_secs(2))));
+                }
+            } else {
+                // we are not associated
+                if let Some(eip) = eips
+                    .iter()
+                    .find(|eip| eip.matches_pod_name(&pod.name_unchecked()) && !eip.attached())
+                {
+                    // we have an eip we want to associate with
+                    info!("Pod {} found a matching unattached EIP {}, asking it to reconcile, and rescheduling reconciliation", eip.name_unchecked(), eip.name_unchecked());
+                    crate::eip::trigger_reconciliation(&eip_api, &eip.name_unchecked()).await?;
+                    return Ok(Some(Action::requeue(Duration::from_secs(2))));
+                } else {
+                    // There are no eips we want to associate with or none are free
+                    info!(
+                        "No matching unattached EIPs for Pod {}",
+                        pod.name_unchecked()
+                    );
+                    return Ok(None);
+                }
+            }
         } else {
+            // there are no eips
             info!(
-                "EIP {} found for pod {} but already claimed by {}",
-                eip_name,
-                name,
-                eip.claim().ok_or(Error::MissingEipClaim)?
+                "No matching unattached EIPs for Pod {}",
+                pod.name_unchecked()
             );
+            return Ok(None);
         }
-
-        Ok(None)
     }
 
     #[instrument(skip(self, client, pod), err)]
@@ -87,22 +124,56 @@ impl k8s_controller::Context for Context {
         pod: &Self::Resource,
     ) -> Result<Option<Action>, Self::Error> {
         // remove claim, delete if autocreate
-        let name = pod.metadata.name.as_ref().ok_or(Error::MissingPodUid)?;
         let eip_api = Api::<Eip>::namespaced(client.clone(), &pod.namespace().unwrap());
         let eip = eip_api
             .list(&ListParams::default())
             .await?
             .items
             .into_iter()
-            .find(|eip| eip.claimed_by(name));
-        if should_autocreate_eip(pod) && eip.is_some() {
-            event!(Level::INFO, should_autocreate_eip = true);
-            crate::eip::delete(&eip_api, eip.unwrap().name().ok_or(Error::MissingEipName)?).await?;
-        } else if let Some(eip) = eip {
-            crate::eip::set_status_unclaimed(&eip_api, eip.name().ok_or(Error::MissingEipName)?)
-                .await?;
-        };
-        Ok(None)
+            .find(|eip| eip.matches_pod_name(&pod.name_unchecked()));
+
+        if let Some(eip) = eip {
+            info!(
+                "Pod{} still attached to EIP {}, asking eip to re-reconcile",
+                pod.name_unchecked(),
+                eip.name_unchecked()
+            );
+            // If this is pod auto-creates an eip we should
+            // just delete the eip
+            if should_autocreate_eip(pod) {
+                event!(Level::INFO, should_autocreate_eip = true);
+                crate::eip::delete(&eip_api, &eip.name_unchecked()).await?;
+                return Ok(None);
+            }
+            // We're going to try to disassociate here by asking the eip
+            // to reconile and waiting for some attempts for it to
+            // disassociate with the pod
+            crate::eip::trigger_reconciliation(&eip_api, &eip.name_unchecked()).await?;
+            for _ in 0..5 {
+                let eip = eip_api.get_opt(&eip.name_unchecked()).await?;
+                if let Some(eip) = eip {
+                    if !eip.associated_with_pod(pod) {
+                        info!(
+                            "Pod {} has been disassociated with EIP {}",
+                            pod.name_unchecked(),
+                            eip.name_unchecked()
+                        );
+                        return Ok(None);
+                    }
+                } else {
+                    info!("Pod {} no longer has an attached eip", pod.name_unchecked());
+                    return Ok(None);
+                }
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+            return Err(Error::PodFailedToRemoveEip);
+        } else {
+            info!(
+                "Pod {} is not attached to any EIP, continuing with cleanup",
+                pod.name_unchecked()
+            );
+            Ok(None)
+        }
     }
 }
 

--- a/eip_operator/src/eip.rs
+++ b/eip_operator/src/eip.rs
@@ -167,9 +167,7 @@ pub mod v2 {
         }
 
         pub fn claim(&self) -> Option<&str> {
-            self.status.as_ref().map_or(None, |s| {
-                s.claim.as_ref().map_or(None, |c| Some(c.as_str()))
-            })
+            self.status.as_ref().and_then(|s| s.claim.as_deref())
         }
 
         pub fn claimed_by(&self, name: &str) -> bool {
@@ -244,11 +242,11 @@ pub mod v2 {
             .await?
             .addresses;
             match addresses {
-                None => return Ok(None),
+                None => Ok(None),
                 Some(addrs) => match addrs.len() {
-                    0 => return Ok(None),
+                    0 => Ok(None),
                     1 => return Ok(addrs[0].association_id().map(|id| id.to_owned())),
-                    _ => return Err(Error::MultipleAddressesAssociatedToEip),
+                    _ => Err(Error::MultipleAddressesAssociatedToEip),
                 },
             }
         }

--- a/eip_operator/src/main.rs
+++ b/eip_operator/src/main.rs
@@ -53,7 +53,8 @@ async fn run() -> Result<(), Error> {
     let k8s_client = Client::try_default().await?;
 
     debug!("Getting ec2_client...");
-    let mut config_loader = aws_config::from_env();
+    let mut config_loader = eip_operator_shared::aws_config_loader_default();
+
     if let Ok(endpoint) = std::env::var("AWS_ENDPOINT_URL") {
         config_loader = config_loader.endpoint_url(endpoint);
     }
@@ -253,7 +254,7 @@ async fn report_eip_quota_status(
     quota_client: &ServiceQuotaClient,
 ) -> Result<(), Error> {
     let addresses_result = ec2_client.describe_addresses().send().await?;
-    let allocated = addresses_result.addresses().unwrap_or_default().len();
+    let allocated = addresses_result.addresses().len();
     let quota_result = quota_client
         .get_service_quota()
         .service_code("ec2")

--- a/eip_operator/src/main.rs
+++ b/eip_operator/src/main.rs
@@ -132,7 +132,7 @@ async fn run() -> Result<(), Error> {
     });
 
     tasks.push({
-        let context = controller::node::Context::new(ec2_client.clone(), namespace.clone());
+        let context = controller::node::Context::new(namespace.clone());
         let watch_config = kube_runtime::watcher::Config::default().labels(MANAGE_EIP_LABEL);
         let node_controller = Controller::cluster(k8s_client.clone(), context, watch_config);
         task::spawn(node_controller.run())

--- a/eip_operator_shared/Cargo.toml
+++ b/eip_operator_shared/Cargo.toml
@@ -7,25 +7,23 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-ec2 = { version = "0.28", default-features = false, features = [
-  "native-tls",
-  "rt-tokio",
-] }
-aws-sdk-servicequotas = { version = "0.28", default-features = false, features = [
-  "native-tls",
-  "rt-tokio",
-] }
-aws-smithy-http = { version = "0.55", default-features = false, features = [
-  "rt-tokio",
-] }
+aws-config = { version = "0.101", default-features = false}
+aws-sdk-ec2 = { version = "0.38", default-features = false, features = [ "rt-tokio" ] }
+aws-sdk-servicequotas = { version = "0.38", default-features = false, features = [ "rt-tokio" ] }
+aws-smithy-http = { version = "0.59", default-features = false, features = [ "rt-tokio" ] }
+aws-smithy-runtime-api = "0.101"
+aws-smithy-runtime = { version = "0.101", features = ["connector-hyper-0-14-x"] }
+hyper-tls = { version = "0.5.0" }
+
+
 futures = "0.3"
 hyper = { version = "0.14.27", features = ["http2"] }
-hyper-tls = { version = "0.5.0" }
 kube = { workspace = true }
 kube-runtime = { workspace = true }
 native-tls = { version = "0.2.11", features = ["alpn"] }
-opentelemetry = { version = "0.20", features = ["rt-tokio", "trace"] }
-opentelemetry-otlp = { version = "0.13" }
+opentelemetry = { version = "0.21", features = ["trace"] }
+opentelemetry_sdk = { version = "0.21", features = ["trace", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.14" }
 serde = "1"
 serde_json = "1"
 thiserror = "1"
@@ -33,7 +31,7 @@ tokio-native-tls = { version = "0.3.1" }
 tokio = { workspace = true }
 tonic = { version = "0.9.2", features = ["transport"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.20"
+tracing-opentelemetry = "0.22"
 tracing-subscriber = { version = "0.3", features = [
   "registry",
   "env-filter",

--- a/eip_operator_shared/src/lib.rs
+++ b/eip_operator_shared/src/lib.rs
@@ -53,10 +53,14 @@ pub enum Error {
     NoEipResourceWithThatNodeSelector,
     #[error("EIP does not have a status.")]
     MissingEipStatus,
+    #[error("EIP does not have a a claim, when one was expected.")]
+    MissingEipClaim,
     #[error("EIP does not have a UID in its metadata.")]
     MissingEipUid,
     #[error("EIP does not have a name in its metadata.")]
     MissingEipName,
+    #[error("EIP expected to have association_id but none found.")]
+    MissingAssociationId,
     #[error("Pod not found.")]
     MissingPod,
     #[error("Pod does not have a UID in its metadata.")]
@@ -79,6 +83,8 @@ pub enum Error {
     MalformedProviderId,
     #[error("Multiple elastic IPs are tagged with this pod's UID.")]
     MultipleEipsTaggedForPod,
+    #[error("Multiple Addresses are associated with the eip")]
+    MultipleAddressesAssociatedToEip,
     #[error("allocation_id was None.")]
     MissingAllocationId,
     #[error("public_ip was None.")]
@@ -116,7 +122,7 @@ pub enum Error {
     #[error("AWS disassociate_address reported error: {source}")]
     AwsDisassociateAddress {
         #[from]
-        source: SdkError<DisassociateAddressError>,
+        source: DisassociateAddressError,
     },
     #[error("AWS release_address reported error: {source}")]
     AwsReleaseAddress {

--- a/eip_operator_shared/src/lib.rs
+++ b/eip_operator_shared/src/lib.rs
@@ -57,12 +57,16 @@ pub enum Error {
     MissingEipUid,
     #[error("EIP does not have a name in its metadata.")]
     MissingEipName,
+    #[error("Pod not found.")]
+    MissingPod,
     #[error("Pod does not have a UID in its metadata.")]
     MissingPodUid,
     #[error("Pod does not have a name in its metadata.")]
     MissingPodName,
     #[error("Pod does not have an IP address.")]
     MissingPodIp,
+    #[error("Node not found.")]
+    MissingNode,
     #[error("Node does not have an IP address.")]
     MissingNodeIp,
     #[error("Pod does not have a node name in its spec.")]
@@ -161,15 +165,15 @@ pub enum Error {
         #[from]
         source: tonic::metadata::errors::InvalidMetadataValue,
     },
-    #[error("AddrParse error: {source}")]
-    AddrParse {
-        #[from]
-        source: AddrParseError,
-    },
     #[error("RtNetlink error: {source}")]
     RtNetlink {
         #[from]
         source: rtnetlink::Error,
+    },
+    #[error("AddrParse error: {source}")]
+    AddrParse {
+        #[from]
+        source: AddrParseError,
     },
     #[error("Could not find a rule for that pod installed by Cilium.")]
     CiliumRuleNotFound,


### PR DESCRIPTION
        - transition eip/pod watchers to mostly adjust tags
        - update logic of eip controller to:
          1. validate current claim or remove
          2. detatch if attatched and unclaimed 3. find a pod/node to claim 4. attach to node or pod node 5. update status to reflect the current state          

## Refactor EIP Operator to better handle multiple selector matches


I believe this change set represents the [changes discussed here](https://github.com/MaterializeInc/cloud/issues/6913#issuecomment-1636396483):

```
node:
reconciliation
-  search through eip , find ones that match labels and are unclaimed
-  if no matches nothing
- if matches claim with node uuid

cleanup
  - remove claim from eip


EIP:
reconciliation:
  - if claimed
     - check node/pod conditions - disconnect from terminating resoruces
     - if still claimed 
	associate with claimed node/pod
	return 

  - if unclaimed
      - detach if attached to something
	  - search through nodes / pods
	  - find ones that match and are not terminating
		attatch and update status
		return


Pods: 
basically the same as nodes (except for handling target annotations and auto-create eip)
```


Concerns:
- I'm not sure I understand fully how this interacts with the pod controllers dns_target_annotations. 
- I believe we've walked through all of the scenarios we can think of there are potentially some we hadn't thought of. Hopefully those get spotted during test/review. 
-  In the eip controller, I'm using a mutable status spec to update the resource status as I operate and I patch at the end. I think this works, but I have some concerns that some action will be performed and an error down the line will lead to a an unpatched status. Just wanted to get some thoughts on this. 

Testing:
This passed tests on the first test run which is either very surprising or an indicating that the things I broke our outside our local test scope. Either way I'd like to test this on a personal MZ stack, I'll reach out for some pointers and update this with results. 

** update **
I've tested this on a personal stack. 
- For pods, I deleted envd pods, and added/removed environments, these all seem to work great. 
- For nodes, I deleted egress nodes, and upped the replica count on the egress no-op replica set so two nodes were competing for the same eip. This seems to work great.  In the two nodes case, we wont' swap over until the node with the existing claim removes its claim, likely by termination, although failing to matche eip is a possible reason. In both cases the failover happens super quick and appears stable. 

I believe I've also handled the transition case to this new method. 
To test this I patched the eip resource status to set claims to None, and ensured reconciliation of the EIP correctly maintained the association and only added the new claim value to the status. 

Any happy to do any other recommended testing.