### PR TITLE
iptables and ip rules to send traffic back the same interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "async-stream"
@@ -593,16 +593,16 @@ dependencies = [
 
 [[package]]
 name = "cilium-eip-no-masquerade-agent"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "eip-operator-shared",
  "futures",
- "ipnetwork",
- "k8s-controller",
+ "iptables",
+ "json-patch",
  "k8s-openapi",
  "kube",
- "kube-runtime",
+ "netlink-packet-route",
  "rand",
  "rtnetlink",
  "tokio",
@@ -1232,12 +1232,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnetwork"
-version = "0.20.0"
+name = "iptables"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+checksum = "d39f0d72d0feb83c9b7f4e1fbde2b4a629886f30841127b3f86383831dba2629"
 dependencies = [
- "serde",
+ "lazy_static",
+ "nix 0.27.1",
+ "regex",
 ]
 
 [[package]]
@@ -1540,19 +1542,20 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.4.2"
-source = "git+https://github.com/MaterializeInc/netlink.git?branch=priority_support#b73800bd39ac10b52fd227465d6e86275b9c8b4e"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
  "anyhow",
  "byteorder",
- "libc",
  "netlink-packet-utils",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/netlink.git?branch=priority_support#b73800bd39ac10b52fd227465d6e86275b9c8b4e"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -1564,8 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-utils"
-version = "0.5.1"
-source = "git+https://github.com/MaterializeInc/netlink.git?branch=priority_support#b73800bd39ac10b52fd227465d6e86275b9c8b4e"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1575,8 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.10.0"
-source = "git+https://github.com/MaterializeInc/netlink.git?branch=priority_support#b73800bd39ac10b52fd227465d6e86275b9c8b4e"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842c6770fc4bb33dd902f41829c61ef872b8e38de1405aa0b938b27b8fba12c3"
 dependencies = [
  "bytes",
  "futures",
@@ -1589,8 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.3"
-source = "git+https://github.com/MaterializeInc/netlink.git?branch=priority_support#b73800bd39ac10b52fd227465d6e86275b9c8b4e"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
 dependencies = [
  "bytes",
  "futures",
@@ -1601,11 +1607,22 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
  "cfg-if",
  "libc",
 ]
@@ -2004,14 +2021,18 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rtnetlink"
-version = "0.10.1"
-source = "git+https://github.com/MaterializeInc/netlink.git?branch=priority_support#b73800bd39ac10b52fd227465d6e86275b9c8b4e"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
  "futures",
  "log",
+ "netlink-packet-core",
  "netlink-packet-route",
+ "netlink-packet-utils",
  "netlink-proto",
- "nix",
+ "netlink-sys",
+ "nix 0.26.4",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2933,6 +2934,26 @@ name = "xmlparser"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7af71d8643341260a65f89fa60c0eeaa907f34544d8f6d9b0df72f069b5e74"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9731702e2f0617ad526794ae28fbc6f6ca8849b5ba729666c2a5bc4b6ddee2cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.73.0"
 
 
 # Use this section only to change the source of dependencies that might
@@ -18,12 +18,15 @@ rust-version = "1.66.0"
 [patch.crates-io]
 
 [workspace.dependencies]
+iptables = "0.5"
 json-patch = "1.2.0"
 k8s-controller = "0.2.0"
 k8s-openapi = { version = "0.19", default-features = false, features = [
     "v1_25",
 ] }
+netlink-packet-route = "0.17"
 rand = "0.8"
+rtnetlink = "0.13"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 kube = { version = "0.85.0", features = ["derive"] }
 kube-runtime = "0.85.0"
@@ -32,5 +35,3 @@ async-trait = "0.1.74"
 futures = "0.3"
 
 eip-operator-shared = { path = "eip_operator_shared" }
-# rtnetlink = "0.12.0"
-rtnetlink = { git = "https://github.com/MaterializeInc/netlink.git", branch = "priority_support" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.66.0-slim-bullseye AS chef
+FROM rust:1.73.0-slim-bookworm AS chef
 RUN cargo install --locked cargo-chef
 WORKDIR /workdir
 
@@ -18,7 +18,9 @@ RUN cargo chef cook $CARGO_RELEASE $CARGO_FEATURES --recipe-path recipe.json
 COPY . .
 RUN cargo build $CARGO_RELEASE $CARGO_FEATURES
 
-FROM gcr.io/distroless/cc-debian11
+FROM debian:bookworm-20231030-slim
+RUN apt-get update && apt-get install -y iptables ca-certificates && rm -rf /var/ib/apt/lists/*
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
 COPY --from=builder /workdir/target/*/eip-operator /
 COPY --from=builder /workdir/target/*/cilium-eip-no-masquerade-agent /
 ENTRYPOINT ["./eip-operator"]

--- a/cilium_eip_no_masquerade_agent/Cargo.toml
+++ b/cilium_eip_no_masquerade_agent/Cargo.toml
@@ -1,22 +1,21 @@
 [package]
 name = "cilium-eip-no-masquerade-agent"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = { workspace = true }
+eip-operator-shared = { workspace = true }
 futures = { workspace = true }
-ipnetwork = "0.20"
-k8s-controller = { workspace = true }
+iptables = { workspace = true }
+json-patch = { workspace = true }
 k8s-openapi = { workspace = true }
 kube = { workspace = true, features = ["derive"] }
-kube-runtime = { workspace = true }
+netlink-packet-route = { workspace = true }
 rand = { workspace = true }
 rtnetlink = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-
-eip-operator-shared = { workspace = true }
-async-trait = { workspace = true }

--- a/cilium_eip_no_masquerade_agent/src/main.rs
+++ b/cilium_eip_no_masquerade_agent/src/main.rs
@@ -188,10 +188,10 @@ impl RuleManager {
 
     async fn insert_ip_rule(&mut self, interface_index: u32) -> Result<(), rtnetlink::Error> {
         info!("Inserting ip rule for eth{interface_index}");
-        // ip rule add pref 100 from all fwmark 0x{i}/{FW_MASK} lookup {10 + i}
+        // ip rule add pref 200 from all fwmark 0x{i}/{FW_MASK} lookup {10 + i}
         //
-        // The 100 priority is somewhat arbitrary, but it is before the rules Cilium injects
-        // for the eth0 marks and for in-VPC traffic, but after the local and pod inbound rules.
+        // The 200 priority is somewhat arbitrary, but it is after the rules Cilium injects
+        // for the eth0 marks and for in-VPC traffic, and after the local and pod inbound rules.
         let mut rule_add_request = self
             .ip_rule_handle
             .add()
@@ -199,7 +199,7 @@ impl RuleManager {
             // Cilium starts numbering tables for secondary ENI local traffic at 11.
             .table_id(10 + interface_index)
             .action(1) // Not sure what this action is, but it seems to work
-            .priority(100);
+            .priority(200);
         let message = rule_add_request.message_mut();
         message.nlas.push(Nla::FwMark(interface_index));
         message.nlas.push(Nla::FwMask(FW_MASK));

--- a/cilium_eip_no_masquerade_agent/src/main.rs
+++ b/cilium_eip_no_masquerade_agent/src/main.rs
@@ -1,117 +1,23 @@
+use std::collections::HashSet;
 use std::net::Ipv4Addr;
 
 use futures::{future, StreamExt, TryStream, TryStreamExt};
-use ipnetwork::Ipv4Network;
-use k8s_controller::Controller;
+use iptables::IPTables;
+use json_patch::{PatchOperation, RemoveOperation, TestOperation};
 use k8s_openapi::api::core::v1::Pod;
-use kube::Client;
-use kube_runtime::controller::Action;
-use rtnetlink::packet::rule::Nla;
-use rtnetlink::packet::RuleMessage;
-use rtnetlink::{new_connection, Handle, IpVersion};
-use tracing::{debug, event, info, instrument, Level};
+use kube::api::{ListParams, Patch, PatchParams};
+use kube::{Api, Client as KubeClient, ResourceExt};
+use netlink_packet_route::rule::Nla;
+use netlink_packet_route::RuleMessage;
+use rtnetlink::{new_connection, IpVersion, RuleHandle};
+use tokio::time::{sleep, Duration};
+use tracing::{event, info, trace, Level};
 
 use eip_operator_shared::{run_with_tracing, Error, MANAGE_EIP_LABEL};
 
-struct Context {
-    handle: Handle,
-    vpc_cidr: Ipv4Network,
-}
-
-impl Context {
-    fn new(handle: Handle, vpc_cidr: Ipv4Network) -> Self {
-        Self { handle, vpc_cidr }
-    }
-}
-
-#[async_trait::async_trait]
-impl k8s_controller::Context for Context {
-    type Resource = Pod;
-    type Error = Error;
-
-    const FINALIZER_NAME: &'static str = "eip.materialize.cloud/cilium-no-masquerade-rule";
-
-    #[instrument(skip(self, _client, pod), err)]
-    async fn apply(
-        &self,
-        _client: Client,
-        pod: &Self::Resource,
-    ) -> Result<Option<Action>, Self::Error> {
-        let pod_ip: Ipv4Addr = pod
-            .status
-            .as_ref()
-            .ok_or(Error::MissingPodIp)?
-            .pod_ip
-            .as_ref()
-            .ok_or(Error::MissingPodIp)?
-            .parse()?;
-        let rule_handle = self.handle.rule();
-        let rules = rule_handle.get(IpVersion::V4).execute();
-        let pod_rules = filter_pod_rules(rules, pod_ip).await?;
-
-        // Find table from Cilium's installed rule
-        let table = pod_rules
-            .iter()
-            .find_map(|rule| {
-                if rule.header.dst_len == self.vpc_cidr.prefix()
-                    && rule
-                        .nlas
-                        .contains(&Nla::Destination(self.vpc_cidr.network().octets().to_vec()))
-                {
-                    Some(rule.header.table)
-                } else {
-                    None
-                }
-            })
-            .ok_or(Error::CiliumRuleNotFound)?;
-
-        // If our rule doesn't already exist, install it.
-        if !pod_rules.iter().any(|rule| {
-            rule.header.dst_len == 0 && rule.header.table == table && rule.header.action == 1
-        }) {
-            rule_handle
-                .add()
-                .v4()
-                .source_prefix(pod_ip, 32)
-                .table(table)
-                .action(1) // Not sure what this action is, but it matches the one Cilium is using.
-                .priority(100)
-                .execute()
-                .await?;
-        }
-
-        Ok(None)
-    }
-
-    #[instrument(skip(self, _client, pod), err)]
-    async fn cleanup(
-        &self,
-        _client: Client,
-        pod: &Self::Resource,
-    ) -> Result<Option<Action>, Self::Error> {
-        let name = pod.metadata.name.as_ref().ok_or(Error::MissingPodName)?;
-
-        // Assuming that if it doesn't have an IP during cleanup, that it never had one.
-        if let Some(pod_ip_str) = &pod
-            .status
-            .as_ref()
-            .and_then(|status| status.pod_ip.as_ref())
-        {
-            let pod_ip: Ipv4Addr = pod_ip_str.parse()?;
-            let rule_handle = self.handle.rule();
-            let rules = rule_handle.get(IpVersion::V4).execute().into_stream();
-            let pod_rules = filter_pod_rules(rules, pod_ip).await?;
-            for rule in pod_rules {
-                if rule.header.dst_len == 0 && rule.header.action == 1 {
-                    event!(Level::INFO, pod_name = %name, pod_ip = %pod_ip, rule = ?rule, "Deleting rule.");
-                    rule_handle.del(rule).execute().await?;
-                    break;
-                }
-            }
-        }
-        Ok(None)
-    }
-}
+const FINALIZER_NAME: &str = "eip.materialize.cloud/cilium-no-masquerade-rule";
+const TABLE: &str = "mangle";
+const CHAIN: &str = "CILIUM_PRE_mangle";
 
 async fn filter_pod_rules(
     rules: impl TryStream<Ok = RuleMessage, Error = rtnetlink::Error>,
@@ -130,6 +36,172 @@ async fn filter_pod_rules(
         .collect()
 }
 
+struct RuleManager {
+    iptables: IPTables,
+    ip_rule_handle: RuleHandle,
+    kube_client: KubeClient,
+    global_pod_api: Api<Pod>,
+    node_name: String,
+}
+
+impl RuleManager {
+    async fn new() -> RuleManager {
+        let iptables = iptables::new(false).unwrap();
+
+        let (connection, rtnetlink_handle, _) = new_connection().unwrap();
+        let ip_rule_handle = rtnetlink_handle.rule();
+        tokio::spawn(connection);
+
+        let kube_client = KubeClient::try_default().await.unwrap();
+        let global_pod_api: Api<Pod> = Api::all(kube_client.clone());
+
+        let node_name = std::env::var("NODE_NAME")
+            .expect("NODE_NAME env var must be set to the name of the kubernetes node this agent is running on.");
+
+        RuleManager {
+            iptables,
+            ip_rule_handle,
+            kube_client,
+            global_pod_api,
+            node_name,
+        }
+    }
+
+    async fn cleanup_legacy_per_pod_rules(&self, pod: &Pod) -> Result<(), Error> {
+        let pod_name = pod
+            .metadata
+            .name
+            .as_ref()
+            .ok_or(eip_operator_shared::Error::MissingPodName)?;
+
+        // Assuming that if it doesn't have an IP during cleanup, that it never had one.
+        if let Some(pod_ip_str) = &pod
+            .status
+            .as_ref()
+            .and_then(|status| status.pod_ip.as_ref())
+        {
+            let pod_ip: Ipv4Addr = pod_ip_str.parse()?;
+            let rules = self
+                .ip_rule_handle
+                .get(IpVersion::V4)
+                .execute()
+                .into_stream();
+            let pod_rules = filter_pod_rules(rules, pod_ip).await?;
+            for rule in pod_rules {
+                if rule.header.dst_len == 0 && rule.header.action == 1 {
+                    event!(Level::INFO, pod_name = %pod_name, pod_ip = %pod_ip, rule = ?rule, "Deleting rule.");
+                    self.ip_rule_handle.del(rule).execute().await?;
+                    break;
+                }
+            }
+        }
+        self.remove_finalizer(pod, pod_name).await;
+        Ok(())
+    }
+
+    async fn remove_finalizer(&self, pod: &Pod, pod_name: &str) {
+        // https://docs.rs/kube-runtime/latest/src/kube_runtime/finalizer.rs.html
+        let finalizer_index = pod
+            .finalizers()
+            .iter()
+            .enumerate()
+            .find(|(_, finalizer)| *finalizer == FINALIZER_NAME)
+            .map(|(i, _)| i);
+        if let Some(finalizer_index) = finalizer_index {
+            let pod_api: Api<Pod> =
+                Api::namespaced(self.kube_client.clone(), &pod.namespace().unwrap());
+            let finalizer_path = format!("/metadata/finalizers/{finalizer_index}");
+            pod_api
+                .patch::<Pod>(
+                    pod_name,
+                    &PatchParams::default(),
+                    &Patch::Json(json_patch::Patch(vec![
+                        // All finalizers run concurrently and we use an integer index
+                        // `Test` ensures that we fail instead of deleting someone else's finalizer
+                        PatchOperation::Test(TestOperation {
+                            path: finalizer_path.clone(),
+                            value: FINALIZER_NAME.into(),
+                        }),
+                        PatchOperation::Remove(RemoveOperation {
+                            path: finalizer_path,
+                        }),
+                    ])),
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    async fn wait_for_chain_to_exist(&self) -> Result<(), Box<dyn std::error::Error>> {
+        info!("Waiting for {CHAIN} chain to exist");
+        while !self.iptables.chain_exists(TABLE, CHAIN)? {
+            trace!("{CHAIN} does not exist, sleeping");
+            sleep(Duration::from_secs(1)).await;
+        }
+        Ok(())
+    }
+
+    async fn get_eni_indexes_for_existing_ip_rules(
+        &self,
+    ) -> Result<HashSet<u32>, rtnetlink::Error> {
+        let rules = self.ip_rule_handle.get(IpVersion::V4).execute();
+        rules
+            .try_filter(|rule| future::ready(rule.nlas.contains(&Nla::FwMask(0xf))))
+            .map_ok(|rule| {
+                rule.nlas
+                    .into_iter()
+                    .find_map(|nla| match nla {
+                        Nla::FwMark(i) => Some(i),
+                        _ => None,
+                    })
+                    .expect("There should always be an associated mark if there is a mask.")
+            })
+            .collect::<Vec<Result<u32, rtnetlink::Error>>>()
+            .await
+            .into_iter()
+            .collect()
+    }
+
+    fn ensure_iptables_rule(&self, rule: &str) -> Result<(), Box<dyn std::error::Error>> {
+        if !self.iptables.exists(TABLE, CHAIN, rule)? {
+            event!(Level::INFO, rule = ?rule, "Appending iptables rule");
+            self.iptables.append(TABLE, CHAIN, rule)?;
+        }
+        Ok(())
+    }
+
+    fn ensure_restore_mark_iptables_rule(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let rule = "-i lxc+ -m comment --comment \"cilium: secondary interfaces\" -j CONNMARK --restore-mark --nfmask 0xf --ctmask 0xf";
+        self.ensure_iptables_rule(rule)?;
+        Ok(())
+    }
+
+    fn ensure_mark_iptables_rule(
+        &self,
+        interface_index: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let rule = format!("-i eth{interface_index} -m comment --comment \"cilium: eth{interface_index}\" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x{interface_index}/0xf");
+        self.ensure_iptables_rule(&rule)?;
+        Ok(())
+    }
+
+    async fn insert_ip_rule(&self, interface_index: u32) -> Result<(), rtnetlink::Error> {
+        info!("Inserting ip rule for eth{interface_index}");
+        // ip rule add pref 100 from all fwmark 0x{i}/0xf lookup {10 + i}
+        let mut rule_add_request = self
+            .ip_rule_handle
+            .add()
+            .v4()
+            .table_id(10 + interface_index)
+            .action(1) // Not sure what this action is, but it seems to work
+            .priority(100);
+        let message = rule_add_request.message_mut();
+        message.nlas.push(Nla::FwMark(interface_index));
+        message.nlas.push(Nla::FwMask(0xf));
+        rule_add_request.execute().await
+    }
+}
+
 fn main() -> Result<(), Error> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -139,39 +211,37 @@ fn main() -> Result<(), Error> {
 }
 
 async fn run() -> Result<(), Error> {
-    debug!("Getting k8s_client...");
-    let k8s_client = Client::try_default().await?;
+    let manager = RuleManager::new().await;
 
-    debug!("Getting VPC_CIDR from env...");
-    let vpc_cidr: Ipv4Network = std::env::var("VPC_CIDR")
-        .expect("VPC_CIDR env var must be set to the Cilium native routing CIDR.")
-        .parse()
-        .expect("Invalid VPC_CIDR.");
+    loop {
+        manager.wait_for_chain_to_exist().await.unwrap();
 
-    debug!("Getting NODE_NAME from env...");
-    let node_name = std::env::var("NODE_NAME")
-        .expect("NODE_NAME env var must be set to the name of the kubernetes node this agent is running on.");
+        let existing_ip_rules = manager.get_eni_indexes_for_existing_ip_rules().await?;
 
-    debug!("Getting namespace from env...");
-    let namespace = std::env::var("NAMESPACE").ok();
+        manager.ensure_restore_mark_iptables_rule().unwrap();
 
-    debug!("Getting rtnetlink handle");
-    let (connection, handle, _) = new_connection()?;
-    tokio::spawn(connection);
+        for i in 1..=15 {
+            manager.ensure_mark_iptables_rule(i).unwrap();
 
-    info!("Watching for events...");
-    let context = Context::new(handle, vpc_cidr);
+            if !existing_ip_rules.contains(&i) {
+                manager.insert_ip_rule(i).await.unwrap();
+            }
+        }
 
-    let wc = kube_runtime::watcher::Config::default()
-        .labels(MANAGE_EIP_LABEL)
-        .fields(&format!("spec.nodeName={}", node_name));
+        let pods = manager
+            .global_pod_api
+            .list(
+                &ListParams::default()
+                    .labels(MANAGE_EIP_LABEL)
+                    .fields(&format!("spec.nodeName={}", manager.node_name)),
+            )
+            .await?;
+        for pod in pods {
+            manager.cleanup_legacy_per_pod_rules(&pod).await?;
+        }
 
-    let controller = match namespace {
-        Some(ref namespace) => Controller::namespaced(k8s_client, context, namespace, wc),
-        None => Controller::namespaced_all(k8s_client, context, wc),
-    };
-    controller.run().await;
-
-    debug!("exiting");
-    Ok(())
+        let delay_secs = 600;
+        info!("Done! Will recheck in {delay_secs} seconds");
+        sleep(Duration::from_secs(delay_secs)).await;
+    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,8 @@ skip = [
     { name = "indexmap", version = "2.0.0" },
     { name = "hashbrown", version = "0.12.3" },
     { name = "hashbrown", version = "0.14.0" },
+    { name = "nix", version = "0.26.4" },
+    { name = "nix", version = "0.27.1" },
 ]
 
 # Use `tracing` instead.
@@ -35,6 +37,7 @@ name = "rustls"
 [licenses]
 allow = [
     "Apache-2.0",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "MIT",
     "Unicode-DFS-2016",
@@ -57,4 +60,4 @@ unknown-registry = "deny"
 # remain buildable even if upstream Git repositories disappear. If you don't
 # have permissions to create a fork in the MaterializeInc organization, ask in
 # #eng-infra on Slack.
-allow-org = { github = ["MaterializeInc"] }
+allow-org = { github = [] }


### PR DESCRIPTION
Changes the cilium-eip-no-masquerade-agent to install iptables and ip rules to send traffic back the same interface the connection was established on. It does this node-wide, so it no longer needs per-pod ip rules to send all traffic out the pod's ENI. This is a significant change, as this means that if masquerade is enabled in Cilium, traffic initiated by the pod will now go out the masquerade interface (normally eth0) rather than the pod's ENI.

This also adds code to clean up the older ip rules and to remove the finalizers added by older versions.

The following rules are added to the mangle table:
```
-A CILIUM_PRE_mangle -i lxc+ -m comment --comment "cilium: secondary interfaces" -j CONNMARK --restore-mark --nfmask 0xf --ctmask 0xf
-A CILIUM_PRE_mangle -i eth1 -m comment --comment "cilium: eth1" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x1/0xf
-A CILIUM_PRE_mangle -i eth2 -m comment --comment "cilium: eth2" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x2/0xf
-A CILIUM_PRE_mangle -i eth3 -m comment --comment "cilium: eth3" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x3/0xf
-A CILIUM_PRE_mangle -i eth4 -m comment --comment "cilium: eth4" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x4/0xf
-A CILIUM_PRE_mangle -i eth5 -m comment --comment "cilium: eth5" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x5/0xf
-A CILIUM_PRE_mangle -i eth6 -m comment --comment "cilium: eth6" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x6/0xf
-A CILIUM_PRE_mangle -i eth7 -m comment --comment "cilium: eth7" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x7/0xf
-A CILIUM_PRE_mangle -i eth8 -m comment --comment "cilium: eth8" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x8/0xf
-A CILIUM_PRE_mangle -i eth9 -m comment --comment "cilium: eth9" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x9/0xf
-A CILIUM_PRE_mangle -i eth10 -m comment --comment "cilium: eth10" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x10/0xf
-A CILIUM_PRE_mangle -i eth11 -m comment --comment "cilium: eth11" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x11/0xf
-A CILIUM_PRE_mangle -i eth12 -m comment --comment "cilium: eth12" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x12/0xf
-A CILIUM_PRE_mangle -i eth13 -m comment --comment "cilium: eth13" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x13/0xf
-A CILIUM_PRE_mangle -i eth14 -m comment --comment "cilium: eth14" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x14/0xf
-A CILIUM_PRE_mangle -i eth15 -m comment --comment "cilium: eth15" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x15/0xf
```

And the following ip rules are added:
```
100:    from all fwmark 0x1/0xf lookup 11
100:    from all fwmark 0x2/0xf lookup 12
100:    from all fwmark 0x3/0xf lookup 13
100:    from all fwmark 0x4/0xf lookup 14
100:    from all fwmark 0x5/0xf lookup 15
100:    from all fwmark 0x6/0xf lookup 16
100:    from all fwmark 0x7/0xf lookup 17
100:    from all fwmark 0x8/0xf lookup 18
100:    from all fwmark 0x9/0xf lookup 19
100:    from all fwmark 0xa/0xf lookup 20
100:    from all fwmark 0xb/0xf lookup 21
100:    from all fwmark 0xc/0xf lookup 22
100:    from all fwmark 0xd/0xf lookup 23
100:    from all fwmark 0xe/0xf lookup 24
100:    from all fwmark 0xf/0xf lookup 25
```
Cilium is consistent about how it numbers the tables, and secondary ENIs are numbered starting with 11. There are no AWS instance types that can have more than 15 ENIs, so we just add rules for all 15 up front.

Due to reliance on the iptables client, we switched the base image to debian.

The code is almost entirely rewritten, so it will probably be easier to review just looking at the new code.

There are a few changes to the lints to allow duplicates of `nix` (used by both iptables and rtnetlink) and to allow BSD-2-clause (used by `zerocopy` and already whitelisted in the Materialize repo).