### PR TITLE
fix xmark rules to use hex not decimal values

### DIFF
--- a/cilium_eip_no_masquerade_agent/src/main.rs
+++ b/cilium_eip_no_masquerade_agent/src/main.rs
@@ -181,7 +181,7 @@ impl RuleManager {
         &mut self,
         interface_index: u32,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let rule = format!("-i eth{interface_index} -m comment --comment \"cilium: eth{interface_index}\" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x{interface_index}/{FW_MASK}");
+        let rule = format!("-i eth{interface_index} -m comment --comment \"cilium: eth{interface_index}\" -m addrtype --dst-type UNICAST --limit-iface-in -j CONNMARK --set-xmark 0x{interface_index:x}/{FW_MASK}");
         self.ensure_iptables_rule(&rule)?;
         Ok(())
     }


### PR DESCRIPTION
Fix xmark rules to use hex values, not decimal.

Previously it used the decimal values in a hex string, which ended up being two incorrect hex digits instead of a single correct hex digit (ie: 0x15 instead of 0xf).