### PR TITLE
go back to using incredibly slow but actually working arm build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,26 +40,6 @@ jobs:
           tags: |
             materialize/k8s-eip-operator:${{ github.sha }}
             materialize/k8s-eip-operator:latest
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-  build-mac:
-    needs: lint
-    runs-on: macos-13-xlarge
-    steps:
-      - uses: actions/checkout@v2
-      - uses: douglascamata/setup-docker-macos-action@v1-alpha.10
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v1
-        with:
-          username: materializebot
-          password: ${{ secrets.DOCKER_HUB_MATERIALIZEBOT_API_KEY }}
-      - uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: |
-            materialize/k8s-eip-operator:${{ github.sha }}
-            materialize/k8s-eip-operator:latest
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
With some testing of ARM going on, we'll need multi-arch eip-operator builds. It's painful to revert to https://github.com/MaterializeInc/k8s-eip-operator/pull/399 which took 2 hours to build, but unfortunately it doesn't seem like there's anything faster that actually works on GH Actions right now :/