### PR TITLE
Fix pod cleanup when eip target changes

### DIFF
--- a/eip_operator/src/controller/pod.rs
+++ b/eip_operator/src/controller/pod.rs
@@ -118,8 +118,14 @@ impl k8s_controller::Context for Context {
         let eip_api = Api::<Eip>::namespaced(client.clone(), &pod.namespace().unwrap());
 
         let all_eips = eip_api.list(&ListParams::default()).await?.items;
-        let eip = all_eips.into_iter().find(|eip| eip.matches_pod(&name));
-        if let Some(eip) = eip {
+
+        let eips = all_eips.into_iter().filter(|eip| {
+            eip.status.as_ref().map_or(false, |s| {
+                s.resource_id.as_ref().map_or(false, |r| *r == name)
+            })
+        });
+
+        for eip in eips {
             let allocation_id = eip.allocation_id().ok_or(Error::MissingAllocationId)?;
             let addresses = crate::aws::describe_address(&self.ec2_client, allocation_id)
                 .await?
@@ -131,7 +137,7 @@ impl k8s_controller::Context for Context {
                 }
             }
             crate::eip::set_status_detached(&eip_api, &eip.name_unchecked()).await?;
-        };
+        }
         if should_autocreate_eip(pod) {
             event!(Level::INFO, should_autocreate_eip = true);
             crate::eip::delete(&eip_api, &name).await?;

--- a/eip_operator/src/eip.rs
+++ b/eip_operator/src/eip.rs
@@ -382,7 +382,7 @@ pub(crate) async fn set_status_association_id(
     name: &str,
     association_id: &str,
 ) -> Result<Eip, kube::Error> {
-    event!(Level::INFO, "Updating status for assocaited EIP.");
+    event!(Level::INFO, "Updating status for associated EIP.");
     let patch = serde_json::json!({
         "apiVersion": Eip::version(),
         "kind": "Eip",


### PR DESCRIPTION
Ensure all eips that a pods is associated with are removed.

Detach resource from eip if eip no longer matches associated resource.