### PR TITLE
remove finalizer cleanup code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,15 +547,13 @@ dependencies = [
 
 [[package]]
 name = "cilium-eip-no-masquerade-agent"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "eip-operator-shared",
  "futures",
  "iptables",
  "json-patch",
- "k8s-openapi",
- "kube",
  "netlink-packet-route",
  "rand",
  "rtnetlink",

--- a/README.md
+++ b/README.md
@@ -171,8 +171,6 @@ Cilium (as of 1.12.0) does not seem to support configuring masquerade on a per-p
 
 ##### B. Run a privileged daemonset in the host network to inject ip rules for pods managed by the eip-operator.
 
-You must set the `VPC_CIDR` environment variable to match the Cilium `ipv4NativeRoutingCIDR`. This allows the agent to detect the appropriate table to forward to from the existing Cilium-created rules.
-
 ```yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -193,13 +191,6 @@ spec:
         env:
         - name: RUST_LOG
           value: INFO
-        - name: VPC_CIDR
-          value: 10.2.0.0/16
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
         image: materialize/k8s-eip-operator
         name: eip-operator
         securityContext:

--- a/cilium_eip_no_masquerade_agent/Cargo.toml
+++ b/cilium_eip_no_masquerade_agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cilium-eip-no-masquerade-agent"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -12,8 +12,6 @@ eip-operator-shared = { workspace = true }
 futures = { workspace = true }
 iptables = { workspace = true }
 json-patch = { workspace = true }
-k8s-openapi = { workspace = true }
-kube = { workspace = true }
 netlink-packet-route = { workspace = true }
 rand = { workspace = true }
 rtnetlink = { workspace = true }


### PR DESCRIPTION
Removes finalizer cleanup code. It was only needed to remove finalizers added by older versions.
Updates README.md to remove unnecessary ENV vars.