### PR TITLE
pin build workflow to rust 1.78.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,16 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.78.0
           components: rustfmt, clippy
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
+          toolchain: 1.78.0
           args: -- --check
       - uses: actions-rs/cargo@v1
         with:
+          toolchain: 1.78.0
           command: clippy
   build:
     needs: lint


### PR DESCRIPTION
## Motivation
Pin's the rust version in the build workflow. This should fix CI on main which is complaining since the linting is running using Rust 1.80.1. Seems fine since this repo will soon be archived.