### PR TITLE
use reflector for egress labeling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2631,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ netlink-packet-route = "0.17"
 rand = "0.8"
 rtnetlink = "0.13"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tokio-stream = "0.1"
 kube = { version = "0.92.1", default-features = false, features = ["derive", "openssl-tls"] }
 kube-runtime = "0.92.1"
 tracing = "0.1"

--- a/eip_operator/Cargo.toml
+++ b/eip_operator/Cargo.toml
@@ -23,6 +23,7 @@ schemars = "0.8"
 serde = "1"
 serde_json = "1"
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 
 eip-operator-shared = { workspace = true }

--- a/eip_operator/src/controller.rs
+++ b/eip_operator/src/controller.rs
@@ -1,3 +1,4 @@
+pub(crate) mod egress;
 pub(crate) mod eip;
 pub(crate) mod node;
 pub(crate) mod pod;

--- a/eip_operator/src/controller/node.rs
+++ b/eip_operator/src/controller/node.rs
@@ -186,8 +186,12 @@ impl k8s_controller::Context for Context {
         }
 
         let node_api = Api::<Node>::all(client);
-        crate::egress::add_gateway_status_label(&node_api, node.name_unchecked().as_str(), "false")
-            .await?;
+        crate::controller::egress::add_gateway_status_label(
+            &node_api,
+            node.name_unchecked().as_str(),
+            "false",
+        )
+        .await?;
 
         Ok(None)
     }

--- a/eip_operator/src/main.rs
+++ b/eip_operator/src/main.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::future::ready;
-use std::pin::pin;
+use std::sync::Arc;
 use std::time::Duration;
 
 use aws_config::{BehaviorVersion, ConfigLoader};
@@ -9,19 +8,14 @@ use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_servicequotas::types::ServiceQuota;
 use aws_sdk_servicequotas::Client as ServiceQuotaClient;
 use futures::future::join_all;
-use futures::stream::{once, select_all};
 use futures::StreamExt;
 use json_patch::{PatchOperation, RemoveOperation, TestOperation};
 use k8s_controller::Controller;
 use k8s_openapi::api::core::v1::{Node, Pod};
 use kube::api::{Api, ListParams, Patch, PatchParams};
-use kube::{Client, Resource, ResourceExt};
-use kube_runtime::{reflector, WatchStreamExt};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use tokio::{task, time};
-use tokio_stream::wrappers::{IntervalStream, UnboundedReceiverStream};
-use tracing::{debug, event, info, instrument, warn, Level};
+use kube::{Client, ResourceExt};
+use tokio::task;
+use tracing::{debug, event, info, instrument, Level};
 
 use eip_operator_shared::{run_with_tracing, Error, MANAGE_EIP_LABEL};
 
@@ -29,7 +23,6 @@ use eip::v2::Eip;
 
 mod aws;
 mod controller;
-mod egress;
 mod eip;
 mod kube_ext;
 
@@ -165,28 +158,30 @@ async fn run() -> Result<(), Error> {
 
     tasks.push({
         let eip_api = eip_api.clone();
-        let (eips, eip_notifications) = pin!(make_reflector::<Eip>(&eip_api)).await;
         let node_api = node_api.clone();
+        let context = Arc::new(controller::egress::Context {
+            node_api: node_api.clone(),
+        });
+        let watch_config: kube_runtime::watcher::Config = Default::default();
 
         task::spawn(async move {
-            // Repeating timer to label egress nodes
-            // This allows the egress node to be re-labeled even if a new EIP event is missed
-            let interval = time::interval(Duration::from_secs(300));
-            // timer needs to emit a `()` value for the select_all below
-            let repeating_timer = IntervalStream::new(interval).map(|_| ()).boxed();
-            // run once at startup, every 5 minutes, and every time an EIP changes
-            let mut stream = select_all([
-                once(async {}).boxed(),
-                repeating_timer,
-                UnboundedReceiverStream::new(eip_notifications).boxed(),
-            ]);
-            while let Some(()) = stream.next().await {
-                for eip in eips.state() {
-                    if let Err(err) = crate::egress::label_egress_nodes(&eip, &node_api).await {
-                        event!(Level::ERROR, err = %err, "Node egress labeling reporting error");
+            kube_runtime::controller::Controller::new(eip_api, watch_config)
+                .run(
+                    controller::egress::reconcile,
+                    controller::egress::error_policy,
+                    context,
+                )
+                .for_each(|reconcile_result| async move {
+                    match reconcile_result {
+                        Ok(_) => {
+                            event!(Level::INFO, "Egress Labeling Reconciliation successful");
+                        }
+                        Err(err) => {
+                            event!(Level::ERROR, err = %err, "Reconciliation error");
+                        }
                     }
-                }
-            }
+                })
+                .await;
         })
     });
 
@@ -329,44 +324,4 @@ fn aws_config_loader_default() -> ConfigLoader {
     let hyper_client_builder =
         aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder::new().build(connector);
     aws_config::defaults(BehaviorVersion::latest()).http_client(hyper_client_builder)
-}
-
-/// Create a reflector for the given resource type.
-async fn make_reflector<K>(
-    api: &Api<K>,
-) -> (
-    reflector::Store<K>,
-    tokio::sync::mpsc::UnboundedReceiver<()>,
-)
-where
-    K: kube::Resource
-        + Clone
-        + Send
-        + Sync
-        + DeserializeOwned
-        + Serialize
-        + std::fmt::Debug
-        + 'static,
-    <K as Resource>::DynamicType: Default + std::cmp::Eq + std::hash::Hash + std::clone::Clone,
-{
-    let (notify_write, notify_read) = tokio::sync::mpsc::unbounded_channel();
-    let api = api.clone();
-    let (store, writer) = reflector::store();
-    let watcher = kube_runtime::watcher(api, kube_runtime::watcher::Config::default().timeout(29));
-    task::spawn(async move {
-        watcher
-            .reflect(writer)
-            .for_each(|res| {
-                if let Err(e) = res {
-                    warn!("error in {} reflector: {}", K::kind(&Default::default()), e);
-                }
-                notify_write.send(()).unwrap();
-                ready(())
-            })
-            .await
-    });
-    // the only way this can return an error is if we drop the writer,
-    // which we do not ever do, so unwrap is fine
-    store.wait_until_ready().await.unwrap();
-    (store, notify_read)
 }

--- a/eip_operator_shared/Cargo.toml
+++ b/eip_operator_shared/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1"
 thiserror = "1"
 tokio-native-tls = { version = "0.3.1" }
 tokio = { workspace = true }
-tonic = { version = "0.12.1", features = ["transport"] }
+tonic = { version = "0.12.3", features = ["transport"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.25"
 tracing-subscriber = { version = "0.3", features = [


### PR DESCRIPTION
## Motivation
If the EIP operator pod is unavailable when an egress node rolls, there is a chance the new node will fail to get the `egress-gateway.materialize.cloud/ready-status: true` label. 

Use a reflector instead of a watch for egress labeling. These changes ensure the labeler runs on eip operator startup, on eip changes, and every 5 minutes. Running on a timer ensures if an EIP event is missed, the new node will get the required egress label.

## Notes for reviewer
Works in my development environment. I let it run over the weekend with nodes rolling every 6 hours.